### PR TITLE
Enabled committing an empty user_content folder

### DIFF
--- a/public/user_content/.gitignore
+++ b/public/user_content/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Small fix that will prevent the empty `user_content` folder from being ignored by Git.
All files in the user_content folder will be ignored.