### PR TITLE
Fixed urls for Global Meta file

### DIFF
--- a/resources/views/Shared/Partials/GlobalMeta.blade.php
+++ b/resources/views/Shared/Partials/GlobalMeta.blade.php
@@ -1,31 +1,28 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0">
-<link rel="shortcut icon" href="/assets/images/touch/favicon.ico">
-<link rel="apple-touch-icon" sizes="57x57" href="/assets/images/touch/apple-touch-icon-57x57.png">
-<link rel="apple-touch-icon" sizes="114x114" href="/assets/images/touch/apple-touch-icon-114x114.png">
-<link rel="apple-touch-icon" sizes="72x72" href="/assets/images/touch/apple-touch-icon-72x72.png">
-<link rel="apple-touch-icon" sizes="144x144" href="/assets/images/touch/apple-touch-icon-144x144.png">
-<link rel="apple-touch-icon" sizes="60x60" href="/assets/images/touch/apple-touch-icon-60x60.png">
-<link rel="apple-touch-icon" sizes="120x120" href="/assets/images/touch/apple-touch-icon-120x120.png">
-<link rel="apple-touch-icon" sizes="76x76" href="/assets/images/touch/apple-touch-icon-76x76.png">
-<link rel="apple-touch-icon" sizes="152x152" href="/assets/images/touch/apple-touch-icon-152x152.png">
-<link rel="apple-touch-icon" sizes="180x180" href="/assets/images/touch/apple-touch-icon-180x180.png">
+<link rel="shortcut icon" href="{{ asset('assets/images/touch/favicon.ico')  }}">
+<link rel="apple-touch-icon" sizes="57x57" href="{{ asset("assets/images/touch/apple-touch-icon-57x57.png") }}">
+<link rel="apple-touch-icon" sizes="114x114" href="{{ asset("assets/images/touch/apple-touch-icon-114x114.png") }}">
+<link rel="apple-touch-icon" sizes="72x72" href="{{ asset("assets/images/touch/apple-touch-icon-72x72.png") }}">
+<link rel="apple-touch-icon" sizes="144x144" href="{{ asset("assets/images/touch/apple-touch-icon-144x144.png") }}">
+<link rel="apple-touch-icon" sizes="60x60" href="{{ asset("assets/images/touch/apple-touch-icon-60x60.png") }}">
+<link rel="apple-touch-icon" sizes="120x120" href="{{ asset("assets/images/touch/apple-touch-icon-120x120.png") }}">
+<link rel="apple-touch-icon" sizes="76x76" href="{{ asset("assets/images/touch/apple-touch-icon-76x76.png") }}">
+<link rel="apple-touch-icon" sizes="152x152" href="{{ asset("assets/images/touch/apple-touch-icon-152x152.png") }}">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ asset("assets/images/touch/apple-touch-icon-180x180.png") }}">
 <meta name="apple-mobile-web-app-title" content="Attendize">
-<link rel="icon" type="image/png" href="/assets/images/touch/favicon-192x192.png" sizes="192x192">
-<link rel="icon" type="image/png" href="/assets/images/touch/favicon-160x160.png" sizes="160x160">
-<link rel="icon" type="image/png" href="/assets/images/touch/favicon-96x96.png" sizes="96x96">
-<link rel="icon" type="image/png" href="/assets/images/touch/favicon-16x16.png" sizes="16x16">
-<link rel="icon" type="image/png" href="/assets/images/touch/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" sizes="192x192" href="{{ asset("assets/images/touch/favicon-192x192.png") }}">
+<link rel="icon" type="image/png" sizes="160x160" href="{{ asset("assets/images/touch/favicon-160x160.png") }}">
+<link rel="icon" type="image/png" sizes="96x96" href="{{ asset("assets/images/touch/favicon-96x96.png") }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ asset("assets/images/touch/favicon-16x16.png") }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ asset("assets/images/touch/favicon-32x32.png") }}">
 <meta name="msapplication-TileColor" content="#ffffff">
-<meta name="msapplication-TileImage" content="/assets/images/touch/mstile-144x144.png">
-<meta name="msapplication-config" content="/assets/images/touch/browserconfig.xml">
-<meta name="application-name" content="Attendize">      
+<meta name="msapplication-TileImage" content="{{ url("assets/images/touch/mstile-144x144.png") }}">
+<meta name="msapplication-config" content="{{ url("assets/images/touch/browserconfig.xml") }}">
+<meta name="application-name" content="Attendize">
 <meta name="_token" content="{{ csrf_token() }}" />
 {{--Mobile browser theme colors--}}
 <meta name="theme-color" content="#0398bf">
 <meta name="msapplication-navbutton-color" content="#0398bf">
 <meta name="apple-mobile-web-app-status-bar-style" content="#0398bf">
-
-
-


### PR DESCRIPTION
When you don't run Attendize on a root domain (`http://localhost/attendize/public` for example) the `GlobalMeta.blade.php` file didn't generate the right path to the assets. 
Now using the `asset()` function for the right result.
Note: I also switched the sizes and href properties for the `icon` metatags. Just to have it in the same order as the `apple-touch-icon` metatags.