### PR TITLE
docs: Correct vocabulary in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ https://www.attendize.com
 
 *Attendize* is an open-source event ticketing and event management application built using the Laravel PHP framework. Attendize was created to offer event organisers a simple solution to managing general admission events, without paying extortionate service fees.
 
-> PLEASE NOTE: Attendize is still in the early stages development and therefore is likely to contain bugs. Be weary about using Attendize in a production environment. 
+> PLEASE NOTE: Attendize is still in the early stages development and therefore is likely to contain bugs. Be wary about using Attendize in a production environment. 
 
 ##Features
  - Beautiful mobile friendly event pages


### PR DESCRIPTION
Changed "weary" to "wary" because author is cautioning user against production use at this point.