### PR TITLE
Removed duplicate refund code when issuing a partial refund

### DIFF
--- a/app/Http/Controllers/EventOrdersController.php
+++ b/app/Http/Controllers/EventOrdersController.php
@@ -128,7 +128,6 @@ class EventOrdersController extends MyBaseController
                 $error_message = 'The maximum amount you can refund is '.(money($order->organiser_amount - $order->amount_refunded, $order->event->currency->code));
             }
             if (!$error_message) {
-                // @todo - remove the code repetition here
                 try {
                     $gateway = Omnipay::gateway('stripe');
 
@@ -137,53 +136,37 @@ class EventOrdersController extends MyBaseController
                     ]);
 
                     if ($refund_type === 'full') { /* Full refund */
-
                         $refund_amount = $order->organiser_amount - $order->amount_refunded;
+                    } else { /* Partial refund */
+                        $refund_amount = floatval($refund_amount);
+                    }
 
-                        $request = $gateway->refund([
-                            'transactionReference' => $order->transaction_id,
-                            'amount'               => $refund_amount,
-                            'refundApplicationFee' => floatval($order->booking_fee) > 0 ? true : false,
-                        ]);
+                    $request = $gateway->refund([
+                        'transactionReference' => $order->transaction_id,
+                        'amount'               => $refund_amount,
+                        'refundApplicationFee' => floatval($order->booking_fee) > 0 ? true : false,
+                    ]);
 
-                        $response = $request->send();
+                    $response = $request->send();
 
-                        if ($response->isSuccessful()) {
-                            /* Update the event sales volume*/
-                            $order->event->decrement('sales_volume', $refund_amount);
+                    if ($response->isSuccessful()) {
+                        /* Update the event sales volume*/
+                        $order->event->decrement('sales_volume', $refund_amount);
 
+                        if (($order->organiser_amount - $order->amount_refunded) == 0) {
                             $order->is_refunded = 1;
-                            $order->amount_refunded = $order->organiser_amount;
                             $order->order_status_id = config('attendize.order_refunded');
                         } else {
-                            $error_message = $response->getMessage();
-                        }
-                    } else { /* Partial refund */
-
-                        $refund = $gateway->refund([
-                            'transactionReference' => $order->transaction_id,
-                            'amount'               => floatval($refund_amount),
-                            'refundApplicationFee' => floatval($order->booking_fee) > 0 ? true : false,
-                        ]);
-
-                        $response = $refund->send();
-
-                        if ($response->isSuccessful()) {
-                            /* Update the event sales volume*/
-                            $order->event->decrement('sales_volume', $refund_amount);
-
-                            $order->order_status_id = config('attendize.order_partially_refunded');
-
-                            if (($order->organiser_amount - $order->amount_refunded) == 0) {
-                                $order->is_refunded = 1;
-                                $order->order_status_id = config('attendize.order_refunded');
-                            }
-
                             $order->is_partially_refunded = 1;
-                        } else {
-                            $error_message = $response->getMessage();
+                            $order->order_status_id = config('attendize.order_partially_refunded');
                         }
+
+                        $order->amount_refunded = $order->organiser_amount;
+                        $order->order_status_id = config('attendize.order_refunded');
+                    } else {
+                        $error_message = $response->getMessage();
                     }
+
                     $order->amount_refunded = round(($order->amount_refunded + $refund_amount), 2);
                     $order->save();
                 } catch (\Exeption $e) {


### PR DESCRIPTION
I also fixed a float comparison bug. When i did a partial refund of 25 (total order 25.99) it worked. Then i tried to do another partial at .99 it kept saying the max i could do was .99 (which is what i was doing). Added rounding to 2 decimal places. If we ever support currencies with more than 2 decimal places this will need to be updated. 