### PR TITLE
Migration clean ups to ensure rollbacks work correctly.

### DIFF
--- a/app/Helpers/macros.php
+++ b/app/Helpers/macros.php
@@ -40,19 +40,19 @@ Form::macro('customCheckbox', function ($name, $value, $checked = false, $label 
 Form::macro('styledFile', function ($name, $multiple = false) {
     $out = '<div class="styledFile" id="input-'.$name.'">
         <div class="input-group">
-                                <span class="input-group-btn">
-                                    <span class="btn btn-primary btn-file">
-                                        Browse&hellip; <input name="'.$name.'" type="file" '.($multiple ? 'multiple' : '').'>
-                                    </span>
-                                </span>
-                                <input type="text" class="form-control" readonly>
-                                <span style="display: none;" class="input-group-btn btn-upload-file">
-                                    <span class="btn btn-success ">
-                                        Upload 
-                                    </span>
-                                </span>
-                            </div>
-                                </div>';
+            <span class="input-group-btn">
+                <span class="btn btn-primary btn-file">
+                    Browse&hellip; <input name="'.$name.'" type="file" '.($multiple ? 'multiple' : '').'>
+                </span>
+            </span>
+            <input type="text" class="form-control" readonly>
+            <span style="display: none;" class="input-group-btn btn-upload-file">
+                <span class="btn btn-success ">
+                    Upload
+                </span>
+            </span>
+        </div>
+    </div>';
 
     return $out;
 });

--- a/database/migrations/2014_03_26_180116_create_users_table.php
+++ b/database/migrations/2014_03_26_180116_create_users_table.php
@@ -21,17 +21,13 @@ class CreateUsersTable extends Migration
             $table->text('name');
         });
 
-
         Schema::create('reserved_tickets', function ($table) {
-
             $table->increments('id');
-
             $table->integer('ticket_id');
             $table->integer('event_id');
             $table->integer('quantity_reserved');
             $table->datetime('expires');
             $table->string('session_id', 45);
-
             $table->timestamps();
         });
 
@@ -511,6 +507,7 @@ class CreateUsersTable extends Migration
     {
         $tables = [
             'order_statuses',
+            'ticket_statuses',
             'reserved_tickets',
             'timezones',
             'date_formats',
@@ -527,13 +524,16 @@ class CreateUsersTable extends Migration
             'event_stats',
             'attendees',
             'messages',
-            'event_images'
-
+            'event_images',
         ];
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
 
         foreach($tables as $table) {
             Schema::drop($table);
         }
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
     }
 }

--- a/database/migrations/2016_03_16_193757_create_gateways_table.php
+++ b/database/migrations/2016_03_16_193757_create_gateways_table.php
@@ -32,8 +32,6 @@ class CreateGatewaysTable extends Migration
             $table->foreign('payment_gateway_id')->references('id')->on('payment_gateways')->onDelete('cascade');
             $table->foreign('account_id')->references('id')->on('accounts')->onDelete('cascade');
         });
-
-
     }
 
     /**
@@ -43,7 +41,7 @@ class CreateGatewaysTable extends Migration
      */
     public function down()
     {
+        Schema::drop('account_payment_gateways');
         Schema::drop('payment_gateways');
-        Schema::drop('account_payments_gateways');
     }
 }

--- a/database/migrations/2016_03_16_213041_add_account_payment_id.php
+++ b/database/migrations/2016_03_16_213041_add_account_payment_id.php
@@ -12,7 +12,6 @@ class AddAccountPaymentId extends Migration
      */
     public function up()
     {
-
         Schema::table('orders', function (Blueprint $table) {
             $table->unsignedInteger('payment_gateway_id')->nullable();
             $table->foreign('payment_gateway_id')->references('id')->on('payment_gateways');
@@ -27,7 +26,8 @@ class AddAccountPaymentId extends Migration
     public function down()
     {
         Schema::table('orders', function (Blueprint $table) {
-            //
+            $table->dropForeign('orders_payment_gateway_id_foreign');
+            $table->dropColumn('payment_gateway_id');
         });
     }
 }

--- a/database/migrations/2016_03_16_215709_add_gateway_id_accounts_table.php
+++ b/database/migrations/2016_03_16_215709_add_gateway_id_accounts_table.php
@@ -26,7 +26,8 @@ class AddGatewayIdAccountsTable extends Migration
     public function down()
     {
         Schema::table('accounts', function (Blueprint $table) {
-            //
+            $table->dropForeign('accounts_payment_gateway_id_foreign');
+            $table->dropColumn('payment_gateway_id');
         });
     }
 }


### PR DESCRIPTION
- correctly removed foreign keys before removing columns
- turned off foreign key checks in initial migration to allow tables to
be dropped