### PR TITLE
Fix issue when creating blank folder with filename

### DIFF
--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -152,7 +152,7 @@ class Order extends MyBaseModel
         }
 
         if (!is_dir($pdf_file_path)) {
-            File::makeDirectory($pdf_file_path, 0777, true, true);
+            File::makeDirectory(dirname($pdf_file_path), 0777, true, true);
         }
 
         PDF::setOutputMode('F'); // force to file


### PR DESCRIPTION
Add dirname function in order to avoid to create a blank folder with the filename.