### PR TITLE
Fix for non-unique modal IDs

### DIFF
--- a/resources/views/ManageAccount/Modals/EditAccount.blade.php
+++ b/resources/views/ManageAccount/Modals/EditAccount.blade.php
@@ -30,12 +30,12 @@
                     <div class="col-md-12">
                         <!-- tab -->
                         <ul class="nav nav-tabs">
-                            <li class="active"><a href="#general" data-toggle="tab">General</a></li>
-                            <li><a href="#payment" data-toggle="tab">Payment</a></li>
-                            <li><a href="#users" data-toggle="tab">Users</a></li>
+                            <li class="active"><a href="#general_account" data-toggle="tab">General</a></li>
+                            <li><a href="#payment_account" data-toggle="tab">Payment</a></li>
+                            <li><a href="#users_account" data-toggle="tab">Users</a></li>
                         </ul>
                         <div class="tab-content panel">
-                            <div class="tab-pane active" id="general">
+                            <div class="tab-pane active" id="general_account">
                                 {!! Form::model($account, array('url' => route('postEditAccount'), 'class' => 'ajax ')) !!}
                                 <div class="row">
                                     <div class="col-md-6">
@@ -92,12 +92,12 @@
 
                                 {!! Form::close() !!}
                             </div>
-                            <div class="tab-pane " id="payment">
+                            <div class="tab-pane " id="payment_account">
 
                                @include('ManageAccount.Partials.PaymentGatewayOptions')
 
                             </div>
-                            <div class="tab-pane" id="users">
+                            <div class="tab-pane" id="users_account">
                                 {!! Form::open(array('url' => route('postInviteUser'), 'class' => 'ajax ')) !!}
 
                                 <div class="table-responsive">


### PR DESCRIPTION
Hey. I noticed that there were several elements with the if "general", and it bugged the account settings modal. I simply added a suffix to prevent this issue from happening again.


Documentation of the issue: [Video](https://www.youtube.com/watch?v=QbeKxNKyZAE)