### PR TITLE
Fixes Laravel issue with Cookie Middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -26,7 +26,7 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,


### PR DESCRIPTION
The original original cookie middleware is no longer located in app/http/middleware, so the location has been updated to the Laravel default location.