### PR TITLE
Correct typo in Event Model method

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -56,7 +56,7 @@ class Event extends MyBaseModel
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function questions_with_tashed()
+    public function questions_with_trashed()
     {
         return $this->belongsToMany('\App\Models\Question', 'event_question')->withTrashed();
     }


### PR DESCRIPTION
Corrected a typo in a function name in the Event model. 