### PR TITLE
Two bugfixes

### DIFF
--- a/app/Http/Controllers/EventTicketsController.php
+++ b/app/Http/Controllers/EventTicketsController.php
@@ -44,8 +44,8 @@ class EventTicketsController extends MyBaseController
 
         // Get tickets for event.
         $tickets = empty($q) === false
-            ? $event->tickets()->where('title', 'like', '%' . $q . '%')->orderBy($sort_by, 'desc')->paginate()
-            : $event->tickets()->orderBy($sort_by, 'desc')->paginate();
+            ? $event->tickets()->where('title', 'like', '%' . $q . '%')->orderBy($sort_by, 'asc')->paginate()
+            : $event->tickets()->orderBy($sort_by, 'asc')->paginate();
 
         // Return view.
         return view('ManageEvent.Tickets', compact('event', 'tickets', 'sort_by', 'q', 'allowed_sorts'));

--- a/app/Http/Controllers/EventViewController.php
+++ b/app/Http/Controllers/EventViewController.php
@@ -33,7 +33,7 @@ class EventViewController extends Controller
 
         $data = [
             'event'       => $event,
-            'tickets'     => $event->tickets()->where('is_hidden', 0)->orderBy('sort_order', 'desc')->get(),
+            'tickets'     => $event->tickets()->where('is_hidden', 0)->orderBy('sort_order', 'asc')->get(),
             'is_embedded' => 0,
         ];
         /*

--- a/app/Http/Controllers/EventViewEmbeddedController.php
+++ b/app/Http/Controllers/EventViewEmbeddedController.php
@@ -19,7 +19,7 @@ class EventViewEmbeddedController extends Controller
 
         $data = [
             'event'       => $event,
-            'tickets'     => $event->tickets()->where('is_hidden', 0)->orderBy('sort_order', 'desc')->get(),
+            'tickets'     => $event->tickets()->where('is_hidden', 0)->orderBy('sort_order', 'asc')->get(),
             'is_embedded' => '1',
         ];
 

--- a/resources/views/Public/ViewEvent/Partials/EventCreateOrderSection.blade.php
+++ b/resources/views/Public/ViewEvent/Partials/EventCreateOrderSection.blade.php
@@ -205,7 +205,7 @@
 
                 @if($event->pre_order_display_message)
                 <div class="well well-small">
-                    {{ nl2br(e($event->pre_order_display_message)) }}
+                    {!! nl2br(e($event->pre_order_display_message)) !!}
                 </div>
                 @endif
 


### PR DESCRIPTION
Display as raw HTML after escaping and nl2br:
With current code, `<br/>` will be displayed instead of a line break. This commit fixes the issue.

Make tickets be sorted in ASC order:
In EventTicketsController::postUpdateTicketsOrder, sort_order is generated in ascending order, however, when displaying tickets, tickets is sorted in descending order. 964e456 tries to solve the issue but it is the other way around.