### PR TITLE
Update EventCheckoutController.php : stripe receipts.

### DIFF
--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -352,11 +352,11 @@ class EventCheckoutController extends Controller
                     case config('attendize.payment_gateway_stripe'):
                         $token = $request->get('stripeToken');
                         $transaction_data += [
-                            'token' => $token,
+                            'token'         => $token,
+                            'receipt_email' => $request->get('order_email'),
                         ];
                         break;
                     case config('attendize.payment_gateway_migs'):
-
                         $transaction_data += [
                             'transactionId' => $event_id . date('YmdHis'),       // TODO: Where to generate transaction id?
                             'returnUrl' => route('showEventCheckoutPaymentReturn', [


### PR DESCRIPTION
Added 'receipt_email' to the Stripe charge creation request so customers get a payment receipt as well as their tickets. Also removed a blank line.

I would still like to see the $order->order_reference in the description, but I'm not sure if $order has that property at this point: line 330 of EventCheckoutController.php.