### PR TITLE
Reflect Attendee cancellation in event stats

### DIFF
--- a/app/Http/Controllers/EventAttendeesController.php
+++ b/app/Http/Controllers/EventAttendeesController.php
@@ -701,8 +701,16 @@ class EventAttendeesController extends MyBaseController
         }
 
         $attendee->ticket->decrement('quantity_sold');
+        $attendee->ticket->decrement('sales_volume', $attendee->ticket->price);
+        $attendee->ticket->event->decrement('sales_volume', $attendee->ticket->price);
         $attendee->is_cancelled = 1;
         $attendee->save();
+
+        $eventStats = EventStats::where('event_id', $attendee->event_id)->where('date', $attendee->created_at->format('Y-m-d'))->first();
+        if($eventStats){
+            $eventStats->decrement('tickets_sold',  1);
+            $eventStats->decrement('sales_volume',  $attendee->ticket->price);
+        }
 
         $data = [
             'attendee'   => $attendee,


### PR DESCRIPTION
When an Attendee is cancelled, also remove the Attendee from the stats, to prevent errornous amounts for the event being shown.