### PR TITLE
Fix QR code scanning in Safari (inc. iOS).

### DIFF
--- a/public/assets/javascript/check_in.js
+++ b/public/assets/javascript/check_in.js
@@ -111,18 +111,20 @@ var checkinApp = new Vue({
             qrcode.callback = this.QrCheckin;
             navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 
-            navigator.getUserMedia({video: true, audio: false}, function (stream) {
+            navigator.getUserMedia({
+                video: {
+                    facingMode: 'environment'
+                },
+                audio: false
+            }, function (stream) {
 
                 that.stream = stream;
-                console.log(stream);
+
                 if (that.videoElement.mozSrcObject !== undefined) { // works on firefox now
                     that.videoElement.mozSrcObject = stream;
                 } else if(window.URL) { // and chrome, but must use https
-                    var objectURL = window.URL.createObjectURL(stream);
-                    that.videoElement.src = objectURL || stream;
+                    that.videoElement.srcObject = stream;
                 };
-
-                that.videoElement.play();
 
             }, function () { /* error*/
                 alert(lang("checkin_init_error"));
@@ -170,4 +172,3 @@ var checkinApp = new Vue({
         }
     }
 });
-

--- a/resources/views/ManageEvent/CheckIn.blade.php
+++ b/resources/views/ManageEvent/CheckIn.blade.php
@@ -122,7 +122,7 @@
         <a @click="closeScanner"  class="closeScanner" href="javascript:void(0);">
         <i class="ico-close"></i>
         </a>
-        <video id="scannerVideo" autoplay></video>
+        <video id="scannerVideo" playsinline autoplay></video>
 
         <div class="scannerButtons">
                     <a @click="initScanner" v-show="!isScanning" href="javascript:void(0);">


### PR DESCRIPTION
This change should fix the QR code scanning in Safari, including on iOS. Also tested in latest versions of Chrome & Firefox on OSX.

Addresses issue #385.