### PR TITLE
fix bug where postMessageOrder gets datas of orders table

### DIFF
--- a/app/Http/Controllers/EventOrdersController.php
+++ b/app/Http/Controllers/EventOrdersController.php
@@ -434,7 +434,7 @@ class EventOrdersController extends MyBaseController
             ]);
         }
 
-        $order = Attendee::scope()->findOrFail($order_id);
+        $order = Order::scope()->findOrFail($order_id);
 
         $data = [
             'order'           => $order,


### PR DESCRIPTION
The function postMessageOrder should get datas from Orders not attendees table but orders table on line 437.
So I have fixed it.

I would be happy if I could get your feedback.