### PR TITLE
Add self signed cert to Nginx

### DIFF
--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,2 +1,8 @@
 FROM nginx:latest
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+RUN apt-get update && apt-get install openssl
+RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key -out /etc/ssl/certs/nginx-selfsigned.crt -subj "/C=GB/ST=London/L=London/O=NA/CN=localhost"
+RUN openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
+RUN mkdir /etc/nginx/snippets
+COPY self-signed.conf /etc/nginx/snippets/self-signed.conf
+COPY ssl-params.conf /etc/nginx/snippets/ssl-params.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./.env
     ports:
     - "8080:80"
+    - "8081:443"
     networks:
       - attendizenet
     volumes:

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,6 +2,13 @@ server {
     listen 80 default_server;
     server_name localhost;
 
+    listen 443 ssl http2 default_server;
+    listen [::]:443 ssl http2 default_server;
+
+    include snippets/self-signed.conf;
+    include snippets/ssl-params.conf;
+
+
     root /usr/share/nginx/html/attendize/public;
     index index.php;
 

--- a/self-signed.conf
+++ b/self-signed.conf
@@ -1,0 +1,2 @@
+ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;

--- a/ssl-params.conf
+++ b/ssl-params.conf
@@ -1,0 +1,21 @@
+# from https://cipherli.st/
+# and https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+
+ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+ssl_ecdh_curve secp384r1;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling on;
+ssl_stapling_verify on;
+resolver 8.8.8.8 8.8.4.4 valid=300s;
+resolver_timeout 5s;
+# Disable preloading HSTS for now.  You can use the commented out header line that includes
+# the "preload" directive if you understand the implications.
+#add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+add_header Strict-Transport-Security "max-age=63072000; includeSubdomains";
+add_header X-Frame-Options DENY;
+add_header X-Content-Type-Options nosniff;
+
+ssl_dhparam /etc/ssl/certs/dhparam.pem;


### PR DESCRIPTION
Adds a self signed cert so can use :8081 to do testing on SSL  