### PR TITLE
fixes #376 Sending message to all attendees sends also to cancelled ones

### DIFF
--- a/app/Mailers/AttendeeMailer.php
+++ b/app/Mailers/AttendeeMailer.php
@@ -48,7 +48,11 @@ class AttendeeMailer extends Mailer
                 $message_object->account_id)->get();
 
         foreach ($attendees as $attendee) {
-
+            
+            if ($attendee->is_cancelled) {
+               continue;
+            }
+            
             $data = [
                 'attendee'        => $attendee,
                 'event'           => $event,


### PR DESCRIPTION
Added condition to check if attribute `is_cancelled` for attendee is set to false before sending email.