### PR TITLE
Small typo fix causing 500 error when using french locale

### DIFF
--- a/resources/lang/fr/User.php
+++ b/resources/lang/fr/User.php
@@ -33,4 +33,4 @@ return array (
   'terms_and_conditions' => '&nbsp;&nbsp;J\'accepte <a target="_blank" href=":url"> la charte d\'utilisation </a>',
   'welcome_to_app' => 'Bienvenue sur :app !',
   'your_email' => 'Votre email',
-;
+);


### PR DESCRIPTION
There is a small typo in a french locale file causing HTTP 500 errors on login.