### PR TITLE
Prevent duplicate queries

### DIFF
--- a/app/Http/Controllers/OrganiserEventsController.php
+++ b/app/Http/Controllers/OrganiserEventsController.php
@@ -25,9 +25,9 @@ class OrganiserEventsController extends MyBaseController
         $sort_by = (in_array($request->get('sort_by'), $allowed_sorts) ? $request->get('sort_by') : 'start_date');
 
         $events = $searchQuery
-            ? Event::scope()->where('title', 'like', '%' . $searchQuery . '%')->orderBy($sort_by,
+            ? Event::scope()->with(['organiser', 'currency'])->where('title', 'like', '%' . $searchQuery . '%')->orderBy($sort_by,
                 'desc')->where('organiser_id', '=', $organiser_id)->paginate(12)
-            : Event::scope()->where('organiser_id', '=', $organiser_id)->orderBy($sort_by, 'desc')->paginate(12);
+            : Event::scope()->with(['organiser', 'currency'])->where('organiser_id', '=', $organiser_id)->orderBy($sort_by, 'desc')->paginate(12);
 
         $data = [
             'events'    => $events,

--- a/app/Http/Middleware/FirstRunMiddleware.php
+++ b/app/Http/Middleware/FirstRunMiddleware.php
@@ -21,11 +21,12 @@ class FirstRunMiddleware
          * If there are no organisers then redirect the user to create one
          * else - if there's only one organiser bring the user straight there.
          */
-        if (Organiser::scope()->count() === 0 && !($request->route()->getName() == 'showCreateOrganiser') && !($request->route()->getName() == 'postCreateOrganiser')) {
+        $corganizerCount = Organiser::scope()->count();
+        if ($corganizerCount === 0 && !($request->route()->getName() == 'showCreateOrganiser') && !($request->route()->getName() == 'postCreateOrganiser')) {
             return redirect(route('showCreateOrganiser', [
                 'first_run' => '1',
             ]));
-        } elseif (Organiser::scope()->count() === 1 && ($request->route()->getName() == 'showSelectOrganiser')) {
+        } elseif ($corganizerCount === 1 && ($request->route()->getName() == 'showSelectOrganiser')) {
             return redirect(route('showOrganiserDashboard', [
                 'organiser_id' => Organiser::scope()->first()->id,
             ]));

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -12,6 +12,8 @@ class Ticket extends MyBaseModel
 
     protected $dates = ['start_sale_date', 'end_sale_date'];
 
+    protected $quantity_reserved_cache = null;
+
     /**
      * The rules to validate the model.
      *
@@ -144,12 +146,17 @@ class Ticket extends MyBaseModel
      */
     public function getQuantityReservedAttribute()
     {
-        $reserved_total = DB::table('reserved_tickets')
-            ->where('ticket_id', $this->id)
-            ->where('expires', '>', Carbon::now())
-            ->sum('quantity_reserved');
+        if (is_null($this->quantity_reserved_cache)) {
+            $reserved_total = DB::table('reserved_tickets')
+                ->where('ticket_id', $this->id)
+                ->where('expires', '>', Carbon::now())
+                ->sum('quantity_reserved');
 
-        return $reserved_total;
+            $this->quantity_reserved_cache = $reserved_total;
+
+            return $reserved_total;
+        }
+        return $this->quantity_reserved_cache;
     }
 
     /**


### PR DESCRIPTION
The following commit prevents two duplicate queries:

`select count(*) as aggregate from organisers where ((organisers.account_id = 1))`

runs twice because we have `Organiser::scope()->count()` twice in `FirstRunMiddleware`

`select sum(quantity_reserved) as aggregate from reserved_tickets where ticket_id = 1 and expires > '2018-12-07 00:40:19'`

runs 2 or 3 times in event/{id}/tickets because the function `getQuantityReservedAttribute` is called several times and call the database each time the attribute is requested. I suggest that we create an attribute directly in the Ticket model, set it to its actual value once and then serve it directly (soft caching).