### PR TITLE
Force key generate in installer

### DIFF
--- a/app/Http/Controllers/InstallerController.php
+++ b/app/Http/Controllers/InstallerController.php
@@ -222,7 +222,7 @@ class InstallerController extends Controller
 
         //force laravel to regenerate a new key (see key:generate sources)
         Config::set('app.key', $app_key);
-        Artisan::call('key:generate');
+        Artisan::call('key:generate', ['--force' => true]);
         Artisan::call('migrate', ['--force' => true]);
         if (Timezone::count() == 0) {
             Artisan::call('db:seed', ['--force' => true]);


### PR DESCRIPTION
Addresses #458 (and related #524). Forces the application key to be generated.

The `STDIN` error is caused by artisan which expects an input:
```
$ php artisan key:generate
**************************************
*     Application In Production!     *
**************************************

 Do you really wish to run this command? (yes/no) [no]:
 > 
```

We can bypass having to enter an input by forcing the key to be generated.