### PR TITLE
Remove reserved tickets once bought

### DIFF
--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -666,6 +666,11 @@ class EventCheckoutController extends Controller
         //forget the order in the session
         session()->forget('ticket_order_' . $event->id);
 
+        /*
+         * Remove any tickets the user has reserved after they have been ordered for the user
+         */
+        ReservedTickets::where('session_id', '=', session()->getId())->delete();
+
         // Queue up some tasks - Emails to be sent, PDFs etc.
         Log::info('Firing the event');
         event(new OrderCompletedEvent($order));


### PR DESCRIPTION
Addresses #409 .

The remaining tickets are calculated by subtracting the ordered tickets and the reserved tickets from the available tickets. Currently ordered tickets are counted twice before their corresponding reserved tickets have expired. Therefore in this PR we delete the user's reserved tickets once they've successfully bought ordered the tickets.