### PR TITLE
Use the default payment gateway configured for the account.

### DIFF
--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -183,10 +183,17 @@ class EventCheckoutController extends Controller
         if (config('attendize.enable_dummy_payment_gateway') == TRUE) {
             $activeAccountPaymentGateway = new AccountPaymentGateway();
             $activeAccountPaymentGateway->fill(['payment_gateway_id' => config('attendize.payment_gateway_dummy')]);
-            $paymentGateway= $activeAccountPaymentGateway;
+            $paymentGateway = $activeAccountPaymentGateway;
         } else {
-            $activeAccountPaymentGateway = $event->account->active_payment_gateway->count() ? $event->account->active_payment_gateway->firstOrFail() : false;
-            $paymentGateway = $event->account->active_payment_gateway->count() ? $event->account->active_payment_gateway->payment_gateway : false;
+            $activeAccountPaymentGateway = $event->account->getGateway($event->account->payment_gateway_id);
+            //if no payment gateway configured don't go to the next step and show user error
+            if (empty($activeAccountPaymentGateway)) {
+                return response()->json([
+                    'status'  => 'error',
+                    'message' => 'No payment gateway configured',
+                ]);
+            }
+            $paymentGateway = $activeAccountPaymentGateway->payment_gateway;
         }
 
         /*

--- a/app/Http/Controllers/ManageAccountController.php
+++ b/app/Http/Controllers/ManageAccountController.php
@@ -133,12 +133,6 @@ class ManageAccountController extends MyBaseController
             case config('attendize.payment_gateway_paypal') : //PayPal
                 $config = $request->get('paypal');
                 break;
-            case config('attendize.payment_gateway_coinbase') : //BitPay
-                $config = $request->get('coinbase');
-                break;
-			case config('attendize.payment_gateway_migs') : //MIGS
-				$config = $request->get('migs');
-				break;
         }
 
         $account_payment_gateway = AccountPaymentGateway::firstOrNew(
@@ -146,6 +140,7 @@ class ManageAccountController extends MyBaseController
                 'payment_gateway_id' => $gateway_id,
                 'account_id'         => $account->id,
             ]);
+
         $account_payment_gateway->config = $config;
         $account_payment_gateway->account_id = $account->id;
         $account_payment_gateway->payment_gateway_id = $gateway_id;


### PR DESCRIPTION
1) Removed references to Bitpay and Migs.
2) Use the payment Gateway configured for the account. Fixes #551.
3) Allows switching of default payment gateway between Stripe and Paypal.