### PR TITLE
Stop duplicate access codes

### DIFF
--- a/app/Http/Controllers/EventAccessCodesController.php
+++ b/app/Http/Controllers/EventAccessCodesController.php
@@ -29,7 +29,6 @@ class EventAccessCodesController extends MyBaseController
     public function postCreate(Request $request, $event_id)
     {
         $eventAccessCode = new EventAccessCodes();
-
         if (!$eventAccessCode->validate($request->all())) {
             return response()->json([
                 'status'   => 'error',
@@ -37,16 +36,28 @@ class EventAccessCodesController extends MyBaseController
             ]);
         }
 
+        $newAccessCode = strtoupper(strip_tags($request->get('code')));
+        if (EventAccessCodes::findFromCode($newAccessCode, $event_id)->count() > 0) {
+            return response()->json([
+                'status'   => 'error',
+                'messages' => [
+                    'code' => [
+                        trans('EventAccessCode.unique_error'),
+                    ],
+                ],
+            ]);
+        }
+
         $eventAccessCode->event_id = $event_id;
-        $eventAccessCode->code = strtoupper(strip_tags($request->get('code')));
+        $eventAccessCode->code = $newAccessCode;
         $eventAccessCode->save();
 
         session()->flash('message', 'Successfully Created Access Code');
 
         return response()->json([
-            'status'      => 'success',
-            'id'          => $eventAccessCode->id,
-            'message'     => trans("Controllers.refreshing"),
+            'status' => 'success',
+            'id' => $eventAccessCode->id,
+            'message' => trans("Controllers.refreshing"),
             'redirectUrl' => route('showEventCustomize', [
                 'event_id' => $event_id,
                 '#access_codes',

--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -183,10 +183,17 @@ class EventCheckoutController extends Controller
         if (config('attendize.enable_dummy_payment_gateway') == TRUE) {
             $activeAccountPaymentGateway = new AccountPaymentGateway();
             $activeAccountPaymentGateway->fill(['payment_gateway_id' => config('attendize.payment_gateway_dummy')]);
-            $paymentGateway= $activeAccountPaymentGateway;
+            $paymentGateway = $activeAccountPaymentGateway;
         } else {
-            $activeAccountPaymentGateway = $event->account->active_payment_gateway->count() ? $event->account->active_payment_gateway->firstOrFail() : false;
-            $paymentGateway = $event->account->active_payment_gateway->count() ? $event->account->active_payment_gateway->payment_gateway : false;
+            $activeAccountPaymentGateway = $event->account->getGateway($event->account->payment_gateway_id);
+            //if no payment gateway configured don't go to the next step and show user error
+            if (empty($activeAccountPaymentGateway)) {
+                return response()->json([
+                    'status'  => 'error',
+                    'message' => 'No payment gateway configured',
+                ]);
+            }
+            $paymentGateway = $activeAccountPaymentGateway->payment_gateway;
         }
 
         /*
@@ -665,6 +672,11 @@ class EventCheckoutController extends Controller
         DB::commit();
         //forget the order in the session
         session()->forget('ticket_order_' . $event->id);
+
+        /*
+         * Remove any tickets the user has reserved after they have been ordered for the user
+         */
+        ReservedTickets::where('session_id', '=', session()->getId())->delete();
 
         // Queue up some tasks - Emails to be sent, PDFs etc.
         Log::info('Firing the event');

--- a/app/Http/Controllers/EventOrdersController.php
+++ b/app/Http/Controllers/EventOrdersController.php
@@ -350,10 +350,9 @@ class EventOrdersController extends MyBaseController
 
             $excel->sheet('orders_sheet_1', function ($sheet) use ($event) {
 
-                \DB::connection()->setFetchMode(\PDO::FETCH_ASSOC);
                 $yes = strtoupper(trans("basic.yes"));
                 $no = strtoupper(trans("basic.no"));
-                $data = DB::table('orders')
+                $orderRows = DB::table('orders')
                     ->where('orders.event_id', '=', $event->id)
                     ->where('orders.event_id', '=', $event->id)
                     ->select([
@@ -367,9 +366,14 @@ class EventOrdersController extends MyBaseController
                         'orders.amount_refunded',
                         'orders.created_at',
                     ])->get();
-                //DB::raw("(CASE WHEN UNIX_TIMESTAMP(`attendees.arrival_time`) = 0 THEN '---' ELSE 'd' END) AS `attendees.arrival_time`"))
 
-                $sheet->fromArray($data);
+                $exportedOrders = $orderRows->toArray();
+
+                array_walk($exportedOrders, function(&$value) {
+                    $value = (array)$value;
+                });
+
+                $sheet->fromArray($exportedOrders);
 
                 // Add headings to first row
                 $sheet->row(1, [

--- a/app/Http/Controllers/InstallerController.php
+++ b/app/Http/Controllers/InstallerController.php
@@ -222,7 +222,7 @@ class InstallerController extends Controller
 
         //force laravel to regenerate a new key (see key:generate sources)
         Config::set('app.key', $app_key);
-        Artisan::call('key:generate');
+        Artisan::call('key:generate', ['--force' => true]);
         Artisan::call('migrate', ['--force' => true]);
         if (Timezone::count() == 0) {
             Artisan::call('db:seed', ['--force' => true]);

--- a/app/Http/Controllers/ManageAccountController.php
+++ b/app/Http/Controllers/ManageAccountController.php
@@ -133,12 +133,6 @@ class ManageAccountController extends MyBaseController
             case config('attendize.payment_gateway_paypal') : //PayPal
                 $config = $request->get('paypal');
                 break;
-            case config('attendize.payment_gateway_coinbase') : //BitPay
-                $config = $request->get('coinbase');
-                break;
-			case config('attendize.payment_gateway_migs') : //MIGS
-				$config = $request->get('migs');
-				break;
         }
 
         $account_payment_gateway = AccountPaymentGateway::firstOrNew(
@@ -146,6 +140,7 @@ class ManageAccountController extends MyBaseController
                 'payment_gateway_id' => $gateway_id,
                 'account_id'         => $account->id,
             ]);
+
         $account_payment_gateway->config = $config;
         $account_payment_gateway->account_id = $account->id;
         $account_payment_gateway->payment_gateway_id = $gateway_id;

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Str;
 use URL;
@@ -15,36 +16,34 @@ class Event extends MyBaseModel
 
     /**
      * The validation rules.
-     *
      * @return array $rules
      */
     public function rules()
     {
         $format = config('attendize.default_datetime_format');
         return [
-                'title'               => 'required',
-                'description'         => 'required',
-                'location_venue_name' => 'required_without:venue_name_full',
-                'venue_name_full'     => 'required_without:location_venue_name',
-                'start_date'          => 'required|date_format:"'.$format.'"',
-                'end_date'            => 'required|date_format:"'.$format.'"',
-                'organiser_name'      => 'required_without:organiser_id',
-                'event_image'         => 'mimes:jpeg,jpg,png|max:3000',
-            ];
+            'title' => 'required',
+            'description' => 'required',
+            'location_venue_name' => 'required_without:venue_name_full',
+            'venue_name_full' => 'required_without:location_venue_name',
+            'start_date' => 'required|date_format:"' . $format . '"',
+            'end_date' => 'required|date_format:"' . $format . '"',
+            'organiser_name' => 'required_without:organiser_id',
+            'event_image' => 'mimes:jpeg,jpg,png|max:3000',
+        ];
     }
 
     /**
      * The validation error messages.
-     *
      * @var array $messages
      */
     protected $messages = [
-        'title.required'                       => 'You must at least give a title for your event.',
-        'organiser_name.required_without'      => 'Please create an organiser or select an existing organiser.',
-        'event_image.mimes'                    => 'Please ensure you are uploading an image (JPG, PNG, JPEG)',
-        'event_image.max'                      => 'Please ensure the image is not larger then 3MB',
+        'title.required' => 'You must at least give a title for your event.',
+        'organiser_name.required_without' => 'Please create an organiser or select an existing organiser.',
+        'event_image.mimes' => 'Please ensure you are uploading an image (JPG, PNG, JPEG)',
+        'event_image.max' => 'Please ensure the image is not larger then 3MB',
         'location_venue_name.required_without' => 'Please enter a venue for your event',
-        'venue_name_full.required_without'     => 'Please enter a venue for your event',
+        'venue_name_full.required_without' => 'Please enter a venue for your event',
     ];
 
     /**
@@ -54,7 +53,7 @@ class Event extends MyBaseModel
      */
     public function questions()
     {
-        return $this->belongsToMany(\App\Models\Question::class, 'event_question');
+        return $this->belongsToMany(Question::class, 'event_question');
     }
 
     /**
@@ -64,27 +63,27 @@ class Event extends MyBaseModel
      */
     public function questions_with_trashed()
     {
-        return $this->belongsToMany(\App\Models\Question::class, 'event_question')->withTrashed();
+        return $this->belongsToMany(Question::class, 'event_question')->withTrashed();
     }
 
     /**
      * The attendees associated with the event.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function attendees()
     {
-        return $this->hasMany(\App\Models\Attendee::class);
+        return $this->hasMany(Attendee::class);
     }
 
     /**
      * The images associated with the event.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function images()
     {
-        return $this->hasMany(\App\Models\EventImage::class);
+        return $this->hasMany(EventImage::class);
     }
 
     /**
@@ -94,57 +93,57 @@ class Event extends MyBaseModel
      */
     public function messages()
     {
-        return $this->hasMany(\App\Models\Message::class)->orderBy('created_at', 'DESC');
+        return $this->hasMany(Message::class)->orderBy('created_at', 'DESC');
     }
 
     /**
      * The tickets associated with the event.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function tickets()
     {
-        return $this->hasMany(\App\Models\Ticket::class);
+        return $this->hasMany(Ticket::class);
     }
 
     /**
      * The stats associated with the event.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function stats()
     {
-        return $this->hasMany(\App\Models\EventStats::class);
+        return $this->hasMany(EventStats::class);
     }
 
     /**
      * The affiliates associated with the event.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function affiliates()
     {
-        return $this->hasMany(\App\Models\Affiliate::class);
+        return $this->hasMany(Affiliate::class);
     }
 
     /**
      * The orders associated with the event.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function orders()
     {
-        return $this->hasMany(\App\Models\Order::class);
+        return $this->hasMany(Order::class);
     }
 
     /**
      * The access codes associated with the event.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function access_codes()
     {
-        return $this->hasMany(\App\Models\EventAccessCodes::class, 'event_id', 'id');
+        return $this->hasMany(EventAccessCodes::class, 'event_id', 'id');
     }
 
     /**
@@ -154,7 +153,7 @@ class Event extends MyBaseModel
      */
     public function account()
     {
-        return $this->belongsTo(\App\Models\Account::class);
+        return $this->belongsTo(Account::class);
     }
 
     /**
@@ -164,7 +163,7 @@ class Event extends MyBaseModel
      */
     public function currency()
     {
-        return $this->belongsTo(\App\Models\Currency::class);
+        return $this->belongsTo(Currency::class);
     }
 
     /**
@@ -174,7 +173,7 @@ class Event extends MyBaseModel
      */
     public function organiser()
     {
-        return $this->belongsTo(\App\Models\Organiser::class);
+        return $this->belongsTo(Organiser::class);
     }
 
     /**
@@ -288,14 +287,13 @@ class Event extends MyBaseModel
             'Order Ref',
             'Attendee Name',
             'Attendee Email',
-            'Attendee Ticket'
+            'Attendee Ticket',
         ], $this->questions->pluck('title')->toArray());
 
         $attendees = $this->attendees()->has('answers')->get();
 
         foreach ($attendees as $attendee) {
             $answers = [];
-
             foreach ($this->questions as $question) {
                 if (in_array($question->id, $attendee->answers->pluck('question_id')->toArray())) {
                     $answers[] = $attendee->answers->where('question_id', $question->id)->first()->answer_text;
@@ -308,7 +306,7 @@ class Event extends MyBaseModel
                 $attendee->order->order_reference,
                 $attendee->full_name,
                 $attendee->email,
-                $attendee->ticket->title
+                $attendee->ticket->title,
             ], $answers);
         }
 
@@ -361,8 +359,10 @@ class Event extends MyBaseModel
      */
     public function getEventUrlAttribute()
     {
-        return route("showEventPage", ["event_id"=>$this->id, "event_slug"=>Str::slug($this->title)]);
-        //return URL::to('/') . '/e/' . $this->id . '/' . Str::slug($this->title);
+        return route("showEventPage", [
+            'event_id' => $this->id,
+            'event_slug' => Str::slug($this->title),
+        ]);
     }
 
     /**
@@ -385,6 +385,9 @@ class Event extends MyBaseModel
         return ['created_at', 'updated_at', 'start_date', 'end_date'];
     }
 
+    /**
+     * @return string
+     */
     public function getIcsForEvent()
     {
         $siteUrl = URL::to('/');

--- a/app/Models/EventAccessCodes.php
+++ b/app/Models/EventAccessCodes.php
@@ -2,7 +2,10 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Collection;
 
 class EventAccessCodes extends MyBaseModel
 {
@@ -23,15 +26,28 @@ class EventAccessCodes extends MyBaseModel
     /**
      * The Event associated with the event access code.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function event()
     {
-        return $this->belongsTo(\App\Models\Event::class, 'event_id', 'id');
+        return $this->belongsTo(Event::class, 'event_id', 'id');
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @param $code
+     * @param $event_id
+     * @return Collection
+     */
+    public static function findFromCode($code, $event_id)
+    {
+        return (new static())
+            ->where('code', $code)
+            ->where('event_id', $event_id)
+            ->get();
+    }
+
+    /**
+     * @return BelongsToMany
      */
     function tickets()
     {

--- a/resources/lang/en/EventAccessCode.php
+++ b/resources/lang/en/EventAccessCode.php
@@ -7,4 +7,5 @@ return [
     'create_access_code' => 'Create Access Code',
     'access_code_title' => 'Code',
     'access_code_title_placeholder' => 'ex: CONFERENCE2019',
+    'unique_error' => 'Code already used for this event',
 ];

--- a/resources/lang/fr/Public_ViewEvent.php
+++ b/resources/lang/fr/Public_ViewEvent.php
@@ -31,7 +31,7 @@ return array (
   'download_tickets' => 'Télécharger les billets',
   'email' => 'Courriel',
   'email_address' => 'Adresse de courriel',
-  'event_already' => 'L\'événement a :started.',
+  'event_already' => 'L\'événement est :started.',
   'event_already_ended' => 'fini',
   'event_already_started' => 'déjà commencé',
   'event_dashboard' => 'Tableau de bord de l\'événement',


### PR DESCRIPTION
# Summary

We needed event hidden access codes to be unique per event.

## Changes

- General code cleanup in the areas i visited
- Added a check when adding a new code if one already exists on the event
- Show error on the admin panel if a duplicate exists for the specific event

## Value

Keeps the database clean.