### PR TITLE
manage event currency

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -220,6 +220,7 @@ class EventController extends MyBaseController
         }
 
         $event->is_live = $request->get('is_live');
+        $event->currency_id = $request->get('currency_id');
         $event->title = $request->get('title');
         $event->description = strip_tags($request->get('description'));
         $event->start_date = $request->get('start_date');

--- a/app/Http/Controllers/EventCustomizeController.php
+++ b/app/Http/Controllers/EventCustomizeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Event;
 use File;
 use Illuminate\Http\Request;
+use App\Models\Currency;
 use Image;
 use Validator;
 
@@ -20,6 +21,7 @@ class EventCustomizeController extends MyBaseController
     public function showCustomize($event_id = '', $tab = '')
     {
         $data = $this->getEventViewData($event_id, [
+					  'currencies'               	 => Currency::pluck('title', 'id'),
             'available_bg_images'        => $this->getAvailableBackgroundImages(),
             'available_bg_images_thumbs' => $this->getAvailableBackgroundImagesThumbs(),
             'tab'                        => $tab,

--- a/resources/lang/en/ManageEvent.php
+++ b/resources/lang/en/ManageEvent.php
@@ -23,6 +23,7 @@ return array (
   'confirm_order_cancel' => 'Confirm Order Cancel',
   'create_attendees' => 'Create Attendees',
   'create_ticket' => 'Create Ticket',
+	'default_currency' => 'Default currency',
   'download_pdf_ticket' => 'Download PDF Ticket',
   'edit_attendee' => 'Edit Attendee',
   'edit_attendee_title' => 'Edit :attendee',

--- a/resources/views/ManageEvent/Partials/EditEventForm.blade.php
+++ b/resources/views/ManageEvent/Partials/EditEventForm.blade.php
@@ -5,6 +5,10 @@
 <div class="row">
     <div class="col-md-12">
         <div class="form-group">
+          {!! Form::label('currency_id', trans("ManageEvent.default_currency"), array('class'=>'control-label required')) !!}
+          {!! Form::select('currency_id', $currencies, $event->currency_id, ['class' => 'form-control']) !!}
+        </div>
+        <div class="form-group">
             {!! Form::label('is_live', trans("Event.event_visibility"), array('class'=>'control-label required')) !!}
             {!!  Form::select('is_live', [
             '1' => trans("Event.vis_public"),


### PR DESCRIPTION
Event currencies were previously only saved upon event creation and weren't able to be updated.  You can now change currency at the event level.