### PR TITLE
Bug : total sales is incorrect (organiser fees are included twice)

### DIFF
--- a/resources/views/ManageEvent/Dashboard.blade.php
+++ b/resources/views/ManageEvent/Dashboard.blade.php
@@ -100,8 +100,13 @@
                         <div class="panel-heading panel-default">
                             <h3 class="panel-title">
                                 @lang("Dashboard.ticket_sales_volume")
+<<<<<<< HEAD
                                 <span style="color: green; float: right;">
                                     {{money($event->sales_volume + $event->organiser_fees_volume, $event->currency)}}
+=======
+                                <span class="panel-meta-success">
+                                    {{money($event->sales_volume, $event->currency)}}
+>>>>>>> dcd171a... Correct sales volume in 2 other files
                                     @lang("basic.total")
                                 </span>
                             </h3>

--- a/resources/views/ManageEvent/Dashboard.blade.php
+++ b/resources/views/ManageEvent/Dashboard.blade.php
@@ -42,7 +42,7 @@
     <div class="row">
         <div class="col-sm-3">
             <div class="stat-box">
-                <h3>{{ money($event->sales_volume + $event->organiser_fees_volume, $event->currency) }}</h3>
+                <h3>{{ money($event->sales_volume, $event->currency) }}</h3>
                 <span>@lang("Dashboard.sales_volume")</span>
             </div>
         </div>

--- a/resources/views/ManageEvent/Dashboard.blade.php
+++ b/resources/views/ManageEvent/Dashboard.blade.php
@@ -83,9 +83,9 @@
                         <div class="panel-heading panel-default">
                             <h3 class="panel-title">
                                 @lang("Dashboard.tickets_sold")
-                        <span style="color: green; float: right;">
-                            {{$event->tickets->sum('quantity_sold')}} @lang("basic.total")
-                        </span>
+                                <span style="color: green; float: right;">
+                                    {{$event->tickets->sum('quantity_sold')}} @lang("basic.total")
+                                </span>
                             </h3>
                         </div>
                         <div class="panel-body">
@@ -100,13 +100,8 @@
                         <div class="panel-heading panel-default">
                             <h3 class="panel-title">
                                 @lang("Dashboard.ticket_sales_volume")
-<<<<<<< HEAD
                                 <span style="color: green; float: right;">
-                                    {{money($event->sales_volume + $event->organiser_fees_volume, $event->currency)}}
-=======
-                                <span class="panel-meta-success">
                                     {{money($event->sales_volume, $event->currency)}}
->>>>>>> dcd171a... Correct sales volume in 2 other files
                                     @lang("basic.total")
                                 </span>
                             </h3>

--- a/resources/views/ManageOrganiser/Dashboard.blade.php
+++ b/resources/views/ManageOrganiser/Dashboard.blade.php
@@ -72,6 +72,16 @@
             </span>
             </div>
         </div>
+        <div class="col-sm-4">
+            <div class="stat-box">
+                <h3>
+                    {{ money($organiser->events->sum('sales_volume'), $organiser->account->currency) }}
+                </h3>
+            <span>
+                @lang("Organiser.sales_volume")
+            </span>
+            </div>
+        </div>
     </div>
 
     <div class="row">

--- a/resources/views/ManageOrganiser/Partials/EventPanel.blade.php
+++ b/resources/views/ManageOrganiser/Partials/EventPanel.blade.php
@@ -32,7 +32,7 @@
 
             <li>
                 <div class="section">
-                    <h4 class="nm">{{{money($event->sales_volume + $event->organiser_fees_volume, $event->currency)}}}</h4>
+                    <h4 class="nm">{{{money($event->sales_volume, $event->currency)}}}</h4>
                     <p class="nm text-muted">@lang("Event.revenue")</p>
                 </div>
             </li>


### PR DESCRIPTION
Hi, I was trying to figure out the problem with my `sales volumes`.

It turns out that if I set a fee for my event, **the fee is already included in the event's total sales**, which means adding fees again produces inflated numbers.

This is apparent in the dashboard totals.

I fixed the 2 commits in my installation, hence the PR :smile: