### PR TITLE
Move env to config files

### DIFF
--- a/app/Http/Controllers/EventCheckInController.php
+++ b/app/Http/Controllers/EventCheckInController.php
@@ -168,7 +168,7 @@ class EventCheckInController extends MyBaseController
         if ($attendee->has_arrived) {
             return response()->json([
                 'status'  => 'error',
-                'message' => trans("Controllers.attendee_already_checked_in", ["time"=> $attendee->arrival_time->format(env("DEFAULT_DATETIME_FORMAT"))])
+                'message' => trans("Controllers.attendee_already_checked_in", ["time"=> $attendee->arrival_time->format(config("attendize.default_datetime_format"))])
             ]);
         }
 

--- a/config/attendize.php
+++ b/config/attendize.php
@@ -71,5 +71,6 @@ return [
     'cdn_url_user_assets'   => '',
     'cdn_url_static_assets' => '',
 
+    'google_analytics_id' => env('GOOGLE_ANALYTICS_ID'),
     'google_maps_geocoding_key' => env('GOOGLE_MAPS_GEOCODING_KEY')
 ];

--- a/config/attendize.php
+++ b/config/attendize.php
@@ -69,5 +69,7 @@ return [
     'default_payment_gateway'    => 1, #Stripe=1 Paypal=2
 
     'cdn_url_user_assets'   => '',
-    'cdn_url_static_assets' => ''
+    'cdn_url_static_assets' => '',
+
+    'google_maps_geocoding_key' => env('GOOGLE_MAPS_GEOCODING_KEY')
 ];

--- a/resources/views/ManageEvent/Customize.blade.php
+++ b/resources/views/ManageEvent/Customize.blade.php
@@ -28,7 +28,7 @@
 @stop
 
 @section('head')
-    {!! HTML::script('https://maps.googleapis.com/maps/api/js?libraries=places&key='.env("GOOGLE_MAPS_GEOCODING_KEY")) !!}
+    {!! HTML::script('https://maps.googleapis.com/maps/api/js?libraries=places&key='.config("attendize.google_maps_geocoding_key")) !!}
     {!! HTML::script('vendor/geocomplete/jquery.geocomplete.min.js') !!}
     <script>
         $(function () {

--- a/resources/views/ManageEvent/Customize.blade.php
+++ b/resources/views/ManageEvent/Customize.blade.php
@@ -245,7 +245,7 @@
                                         <td>{{ $affiliate->visits }}</td>
                                         <td>{{ $affiliate->tickets_sold }}</td>
                                         <td>{{ money($affiliate->sales_volume, $event->currency) }}</td>
-                                        <td>{{ $affiliate->updated_at->format(env("DEFAULT_DATETIME_FORMAT")) }}</td>
+                                        <td>{{ $affiliate->updated_at->format(config("attendize.default_datetime_format")) }}</td>
                                     </tr>
                                 @endforeach
                                 </tbody>

--- a/resources/views/ManageEvent/Modals/MessageAttendees.blade.php
+++ b/resources/views/ManageEvent/Modals/MessageAttendees.blade.php
@@ -84,7 +84,7 @@
                                                 <tr>
                                                     <td class="meta">
                                                         @if($message->sent_at!=null) <?php /* Can occur when there was mailing error*/ ?>
-                                                            <p class="date">{{$message->sent_at->format(env("DEFAULT_DATETIME_FORMAT"))}}</p>
+                                                            <p class="date">{{$message->sent_at->format(config("attendize.default_datetime_format"))}}</p>
                                                         @else
                                                             <p class="date">@lang("Message.unsent")</p>
                                                         @endif

--- a/resources/views/ManageEvent/PrintAttendees.blade.php
+++ b/resources/views/ManageEvent/PrintAttendees.blade.php
@@ -41,7 +41,7 @@
                     <td>{{{$attendee->email}}}</td>
                     <td>{{{$attendee->ticket->title}}}</td>
                     <td>{{{$attendee->order->order_reference}}}</td>
-                    <td>{{$attendee->created_at->format(env("DEFAULT_DATETIME_FORMAT"))}}</td>
+                    <td>{{$attendee->created_at->format(config("attendize.default_datetime_format"))}}</td>
                     <td><input type="checkbox" style="border: 1px solid #000; height: 15px; width: 15px;" /></td>
                 </tr>
                 @endforeach

--- a/resources/views/ManageOrganiser/Dashboard.blade.php
+++ b/resources/views/ManageOrganiser/Dashboard.blade.php
@@ -22,7 +22,7 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/raphael/2.1.4/raphael-min.js" integrity="sha256-Gk+dzc4kV2rqAZMkyy3gcfW6Xd66BhGYjVWa/FjPu+s=" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/morris.js/0.5.1/morris.min.js" integrity="sha256-0rg2VtfJo3VUij/UY9X0HJP7NET6tgAY98aMOfwP0P8=" crossorigin="anonymous"></script>
 
-    {!! HTML::script('https://maps.googleapis.com/maps/api/js?libraries=places&key='.env("GOOGLE_MAPS_GEOCODING_KEY")) !!}
+    {!! HTML::script('https://maps.googleapis.com/maps/api/js?libraries=places&key='.config("attendize.google_maps_geocoding_key")) !!}
     {!! HTML::script('vendor/geocomplete/jquery.geocomplete.min.js')!!}
     {!! HTML::script('vendor/moment/moment.js')!!}
     {!! HTML::script('vendor/fullcalendar/dist/fullcalendar.min.js')!!}

--- a/resources/views/ManageOrganiser/Events.blade.php
+++ b/resources/views/ManageOrganiser/Events.blade.php
@@ -14,7 +14,7 @@
 @stop
 
 @section('head')
-    {!! HTML::script('https://maps.googleapis.com/maps/api/js?libraries=places&key='.env("GOOGLE_MAPS_GEOCODING_KEY")) !!}
+    {!! HTML::script('https://maps.googleapis.com/maps/api/js?libraries=places&key='.config("attendize.google_maps_geocoding_key")) !!}
     {!! HTML::script('vendor/geocomplete/jquery.geocomplete.min.js')!!}
 @stop
 

--- a/resources/views/Shared/Partials/GlobalFooterJS.blade.php
+++ b/resources/views/Shared/Partials/GlobalFooterJS.blade.php
@@ -2,7 +2,7 @@
     <script>showMessage('{{\Session::get('message')}}');</script>
 @endif
 
-@if(env('GOOGLE_ANALYTICS_ID'))
+@if(config('attendize.google_analytics_id'))
 <script>
         (function (i, s, o, g, r, a, m) {
             i['GoogleAnalyticsObject'] = r;
@@ -16,7 +16,7 @@
             m.parentNode.insertBefore(a, m)
         })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
 
-        ga('create', '{{env('GOOGLE_ANALYTICS_ID')}}', 'auto');
+        ga('create', '{{config('attendize.google_analytics_id')}}', 'auto');
         ga('require', 'displayfeatures');
         ga('send', 'pageview');
 </script>


### PR DESCRIPTION
This fixes missing environment values when using `php artisan config:cache` as this should be done in production.