### PR TITLE
Fix bug in en messageReceived email template

### DIFF
--- a/resources/views/en/Emails/messageReceived.blade.php
+++ b/resources/views/en/Emails/messageReceived.blade.php
@@ -5,7 +5,7 @@
 <p>Hi there,</p>
 <p>You have received a message from <b>{{ (isset($sender_name) ? $sender_name : $event->organiser->name) }}</b> in relation to the event <b>{{ $event->title }}</b>.</p>
 <p style="padding: 10px; margin:10px; border: 1px solid #f3f3f3;">
-    {{!! nl2br($message_content !!)}}
+    {!! nl2br($message_content) !!}
 </p>
 
 <p>


### PR DESCRIPTION
I have noticed that the email CONTACT form on the event page is broken.

Can see an error from the log:

```
[2019-06-09 05:50:00] production.ERROR: syntax error, unexpected '!', expecting ',' or ')' (View: /opt/bitnami/apps/attendize/resources/views/en/Emails/messageReceived.blade.php) {"userId":1,"exception":"[object] (ErrorException(code: 0): syntax error, unexpected '!', expecting ',' or ')' (View: /opt/bitnami/apps/attendize/resources/views/en/Emails/messageReceived.blade.php) at /opt/bitnami/apps/attendize/storage/framework/views/7636d50489ed84fa18df11267aa8e9453a5a7392.php:6, Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): syntax error, unexpected '!', expecting ',' or ')' at /opt/bitnami/apps/attendize/storage/framework/views/7636d50489ed84fa18df11267aa8e9453a5a7392.php:6)
```

I think this has been introduced by last template update with a wrong syntax (the PR was #610)