### PR TITLE
Patch for Organizer View

### DIFF
--- a/resources/views/Public/ViewOrganiser/Partials/EventListingPanel.blade.php
+++ b/resources/views/Public/ViewOrganiser/Partials/EventListingPanel.blade.php
@@ -6,7 +6,7 @@
 
             @if(count($events))
 
-                @foreach($events->where('is_live', 1) as $event)
+                @foreach($events as $event)
                     <li>
                         <time datetime="{{ $event->start_date }}">
                             <span class="day">{{ $event->start_date->format('d') }}</span>


### PR DESCRIPTION
Fixed the bug: when all events are private, "There are no Upcoming/Past events to display" boxes won't display