### PR TITLE
Allow checking in with private reference number

### DIFF
--- a/app/Http/Controllers/EventCheckInController.php
+++ b/app/Http/Controllers/EventCheckInController.php
@@ -65,6 +65,7 @@ class EventCheckInController extends MyBaseController
                     )
                     //->orWhere('attendees.email', 'like', $searchQuery . '%')
                     ->orWhere('orders.order_reference', 'like', $searchQuery . '%')
+                    ->orWhere('attendees.private_reference_number', 'like', $searchQuery . '%')
                     ->orWhere('attendees.last_name', 'like', $searchQuery . '%');
             })
             ->select([


### PR DESCRIPTION
Right now, when you use the check-in function to read the generated QR-CODES of the `private_reference_number` value, you won't get the resulting attendee back from the search. With this change, this search criteria will be added.