### PR TITLE
Disable refunds on Stripe

### DIFF
--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -433,6 +433,8 @@ class EventCheckoutController extends Controller
                 session()->push('ticket_order_' . $event_id . '.transaction_data',
                                 $gateway->getTransactionData() + $additionalData);
 
+                $gateway->completeTransaction($additionalData);
+
                 return $this->completeOrder($event_id);
 
             } elseif ($response->isRedirect()) {

--- a/app/Services/PaymentGateway/Dummy.php
+++ b/app/Services/PaymentGateway/Dummy.php
@@ -48,7 +48,7 @@ class Dummy
 
     public function extractRequestParameters($request) {}
 
-    public function completeTransaction($transactionId) {}
+    public function completeTransaction($data) {}
 
     public function getAdditionalData() {}
 

--- a/app/Services/PaymentGateway/Stripe.php
+++ b/app/Services/PaymentGateway/Stripe.php
@@ -56,13 +56,9 @@ class Stripe
         }
     }
 
-    public function completeTransaction($transactionId)
-    {
-    }
+    public function completeTransaction($data) {}
 
-    public function getAdditionalData()
-    {
-    }
+    public function getAdditionalData(){}
 
     public function storeAdditionalData()
     {

--- a/app/Services/PaymentGateway/StripeSCA.php
+++ b/app/Services/PaymentGateway/StripeSCA.php
@@ -76,8 +76,12 @@ class StripeSCA
 
         $paymentIntent = $this->gateway->fetchPaymentIntent($intentData);
         $response = $paymentIntent->send();
+
         if ($response->requiresConfirmation()) {
-            $response = $this->gateway->confirm($intentData)->send();
+            $confirmResponse = $this->gateway->confirm($intentData)->send();
+            if ($confirmResponse->isSuccessful()) {
+                $response = $this->gateway->capture($intentData)->send();
+            }
         } else {
             $response = $this->gateway->capture($intentData)->send();
         }

--- a/app/Services/PaymentGateway/StripeSCA.php
+++ b/app/Services/PaymentGateway/StripeSCA.php
@@ -62,17 +62,24 @@ class StripeSCA
         }
     }
 
-    public function completeTransaction($transactionId = '')
+    public function completeTransaction($data)
     {
-
-        $intentData = [
-            'paymentIntentReference' => $this->options['payment_intent'],
-        ];
+        if (array_key_exists('payment_intent', $data)) {
+            $intentData = [
+                'paymentIntentReference' => $data['payment_intent'],
+            ];
+        } else {
+            $intentData = [
+                'paymentIntentReference' => $this->options['payment_intent'],
+            ];
+        }
 
         $paymentIntent = $this->gateway->fetchPaymentIntent($intentData);
         $response = $paymentIntent->send();
         if ($response->requiresConfirmation()) {
             $response = $this->gateway->confirm($intentData)->send();
+        } else {
+            $response = $this->gateway->capture($intentData)->send();
         }
 
         return $response;

--- a/database/migrations/2019_09_18_082447_disable_refunds_on_stripe_sca.php
+++ b/database/migrations/2019_09_18_082447_disable_refunds_on_stripe_sca.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DisableRefundsOnStripeSca extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('payment_gateways')
+            ->where('name', 'Stripe\PaymentIntents')
+            ->update(['can_refund' => 0]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
Currently refunds is not implemented on the Stripe SCA payment intents gateway.

Therefore refunds will have to be done manually from the stripe Dashboard.