### PR TITLE
fixed spelling in word "continue"

### DIFF
--- a/resources/lang/en/Public_ViewEvent.php
+++ b/resources/lang/en/Public_ViewEvent.php
@@ -27,7 +27,7 @@ return [
   'business_address_code' => 'Code',
   'card_number' => 'Card number',
   'checkout_submit' => 'Checkout',
-  'checkout_order' => 'Contine to Payment',
+  'checkout_order' => 'Continue to Payment',
   'confirmation_email' => 'and a confirmation email have been sent to you.',
   'copy_buyer' => 'Copy buyer details to all ticket holders',
   'currently_not_on_sale' => 'Currently Not On Sale',


### PR DESCRIPTION
This commit fixes a misspelling of the word "continue" which users encounter while buying tickets.