### PR TITLE
Create first pass at Github actions to run tests on next branch

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,0 +1,27 @@
+name: Attendize
+
+on:
+  push:
+    branches:
+      - next
+
+jobs:
+  laravel-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Copy .env
+      run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+    - name: Install Dependencies
+      run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+    - name: Generate key
+      run: php artisan key:generate
+    - name: Create Database
+      run: |
+        mkdir -p database
+        touch database/database.sqlite
+    - name: Execute tests (Unit and Feature tests) via PHPUnit
+      env:
+        DB_CONNECTION: sqlite
+        DB_DATABASE: database/database.sqlite
+      run: vendor/bin/phpunit


### PR DESCRIPTION
## Summary

Small chore to setup github actions to run tests on push operations. This will alleviate some manual testing and start the foundation for automating a bunch of other maintenance things.

We are limiting the actions to `next` only for the time being. Will open it up to everything when `next` is merged into master.