### PR TITLE
Move registration step to the parent window

### DIFF
--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -222,9 +222,9 @@ class EventCheckoutController extends Controller
         if ($request->ajax()) {
             return response()->json([
                 'status'      => 'success',
+                'isEmbedded' => $this->is_embedded,
                 'redirectUrl' => route('showEventCheckout', [
                         'event_id'    => $event_id,
-                        'is_embedded' => $this->is_embedded,
                     ]) . '#order_form',
             ]);
         }

--- a/public/assets/javascript/app-public.js
+++ b/public/assets/javascript/app-public.js
@@ -35,18 +35,21 @@ function getAjaxFormConfig(form) {
             if (data.message) {
                 showMessage(data.message);
             }
+
             switch (data.status) {
                 case 'success':
-
                     if (data.redirectUrl) {
                         if (data.redirectData) {
                             $.redirectPost(data.redirectUrl, data.redirectData);
                         } else {
-                            document.location.href = data.redirectUrl;
+                            if (data.isEmbedded) {
+                                window.parent.location.href = data.redirectUrl;
+                            } else {
+                                document.location.href = data.redirectUrl;
+                            }
                         }
                     }
                     break;
-
                 case 'error':
                     if (data.messages) {
                         processFormErrors($form, data.messages);

--- a/public/assets/javascript/frontend.js
+++ b/public/assets/javascript/frontend.js
@@ -4603,18 +4603,21 @@ function log() {
             if (data.message) {
                 showMessage(data.message);
             }
+
             switch (data.status) {
                 case 'success':
-
                     if (data.redirectUrl) {
                         if (data.redirectData) {
                             $.redirectPost(data.redirectUrl, data.redirectData);
                         } else {
-                            document.location.href = data.redirectUrl;
+                            if (data.isEmbedded) {
+                                window.parent.location.href = data.redirectUrl;
+                            } else {
+                                document.location.href = data.redirectUrl;
+                            }
                         }
                     }
                     break;
-
                 case 'error':
                     if (data.messages) {
                         processFormErrors($form, data.messages);
@@ -4722,7 +4725,7 @@ $(function() {
     $('a').smoothScroll({
         offset: -60
     });
-    
+
     /* Scroll to top */
     $(window).scroll(function() {
         if ($(this).scrollTop() > 100) {


### PR DESCRIPTION
## Summary

The iframe widget is great for embedding specific events into a different website. The checkout flow after that is a bit weird where humans have to try and follow the payment steps inside of an iframe which is not ideal. This might cause a lot of trust and dropoff issues. We aim to fix that by allowing people to hit the registration parts inside of the widget but the subsequent steps after that will open in the parent attendize window.

This change keeps the session data.

### Changes

- Allow for the widget registration to pen the checkout steps in a parent window

### Screenshots

<img width="1087" alt="Screenshot 2019-12-18 at 12 31 01" src="https://user-images.githubusercontent.com/4479918/71078585-5ac4a500-2192-11ea-9acc-b498b877e80f.png">
<img width="1177" alt="Screenshot 2019-12-18 at 12 31 12" src="https://user-images.githubusercontent.com/4479918/71078587-5b5d3b80-2192-11ea-9b98-aef394523715.png">

