### PR TITLE
Event create UI form error handling

### DIFF
--- a/public/assets/javascript/app.js
+++ b/public/assets/javascript/app.js
@@ -470,8 +470,13 @@ function processFormErrors($form, errors)
     $.each(errors, function (index, error) {
         var $input = $('input[name^="' + index + '"]', $form);
 
+        // Fix for description wysiwyg form elements
+        if (index === 'description') {
+            $input = $('.CodeMirror', $form)
+        }
+
         // Try and render a better error message for checkboxes in a table
-        if (index.indexOf('[]')) {
+        if (index.indexOf('[]') > -1) {
             var $formCombinedErrors = $input.closest('form').find('.form-errors');
             // $input.addClass('has-error');
             if ($formCombinedErrors.is(':visible') === false) {

--- a/public/assets/javascript/backend.js
+++ b/public/assets/javascript/backend.js
@@ -9872,8 +9872,13 @@ function processFormErrors($form, errors)
     $.each(errors, function (index, error) {
         var $input = $('input[name^="' + index + '"]', $form);
 
+        // Fix for description wysiwyg form elements
+        if (index === 'description') {
+            $input = $('.CodeMirror', $form)
+        }
+
         // Try and render a better error message for checkboxes in a table
-        if (index.indexOf('[]')) {
+        if (index.indexOf('[]') > -1) {
             var $formCombinedErrors = $input.closest('form').find('.form-errors');
             // $input.addClass('has-error');
             if ($formCombinedErrors.is(':visible') === false) {

--- a/resources/views/ManageOrganiser/Modals/CreateEvent.blade.php
+++ b/resources/views/ManageOrganiser/Modals/CreateEvent.blade.php
@@ -66,6 +66,7 @@
                             {!! Form::styledFile('event_image') !!}
 
                         </div>
+                        @if(!empty(config("attendize.google_maps_geocoding_key")))
                         <div class="form-group address-automatic">
                             {!! Form::label('name', trans("Event.venue_name"), array('class'=>'control-label required ')) !!}
                             {!!  Form::text('venue_name_full', old('venue_name_full'),
@@ -93,7 +94,6 @@
                             </div>
                             <!-- /These are populated with the Google places info-->
                         </div>
-
                         <div class="address-manual" style="display:none;">
                             <h5>
                                 @lang("Event.address_details")
@@ -142,7 +142,6 @@
                                 </div>
                             </div>
                         </div>
-
                         <span>
                             <a data-clear-field=".location_field"
                                data-toggle-class=".address-automatic, .address-manual"
@@ -151,6 +150,56 @@
                             @lang("Event.or(manual/existing_venue)") <b>@lang("Event.enter_manual")</b>
                             </a>
                         </span>
+                        @else
+                        <div class="address-manual">
+                            <h5>
+                                @lang("Event.address_details")
+                            </h5>
+
+                            <div class="form-group">
+                                {!! Form::label('location_venue_name', trans("Event.venue_name"), array('class'=>'control-label required ')) !!}
+                                {!!  Form::text('location_venue_name', old('location_venue_name'), [
+                                        'class'=>'form-control location_field',
+                                        'placeholder'=>trans("Event.venue_name_placeholder")
+                                        ])  !!}
+                            </div>
+                            <div class="form-group">
+                                {!! Form::label('location_address_line_1', trans("Event.address_line_1"), array('class'=>'control-label')) !!}
+                                {!!  Form::text('location_address_line_1', old('location_address_line_1'), [
+                                        'class'=>'form-control location_field',
+                                        'placeholder'=>trans("Event.address_line_1_placeholder")
+                                        ])  !!}
+                            </div>
+                            <div class="form-group">
+                                {!! Form::label('location_address_line_2', trans("Event.address_line_2"), array('class'=>'control-label')) !!}
+                                {!!  Form::text('location_address_line_2', old('location_address_line_2'), [
+                                        'class'=>'form-control location_field',
+                                        'placeholder'=>trans("Event.address_line_2_placeholder")
+                                        ])  !!}
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        {!! Form::label('location_state', trans("Event.city"), array('class'=>'control-label')) !!}
+                                        {!!  Form::text('location_state', old('location_state'), [
+                                                'class'=>'form-control location_field',
+                                                'placeholder'=>trans("Event.city_placeholder")
+                                                ])  !!}
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        {!! Form::label('location_post_code', trans("Event.post_code"), array('class'=>'control-label')) !!}
+                                        {!!  Form::text('location_post_code', old('location_post_code'), [
+                                                'class'=>'form-control location_field',
+                                                'placeholder'=>trans("Event.post_code_placeholder")
+                                                ])  !!}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        @endif
 
                         @if($organiser_id)
                             {!! Form::hidden('organiser_id', $organiser_id) !!}


### PR DESCRIPTION
## Summary

The event create modal UI has some issues that occurred with the next changes. This PR aims to solve 2 of those UI issues where the create screen just hangs on errors.

- There were issues displaying form errors on required fields and the UI would hang indefinitely which provided a bad user experience. It now shows the error messages again and also supports the wysiwyg description box as an element.

- We needed to simplify the event venue address form elements to show the plain input boxes if the `google_maps_geocoding_key` was missing from the `.env`.  It will now only show the static form fields if the key is missing.

### Changes

- Fix form errors not showing up on server error message responses
- Support error handler for wysiwyg textarea inputs as well
- Add check for `attendize.google_maps_geocoding_key` to simplify the UI if the key does not exist

### Screenshots

![Screenshot 2020-03-11 at 19 59 08](https://user-images.githubusercontent.com/4479918/76448845-af636f00-63d3-11ea-8205-23440edc9c79.png)
![Screenshot 2020-03-11 at 19 59 19](https://user-images.githubusercontent.com/4479918/76448850-b12d3280-63d3-11ea-8d57-dae785638476.png)
![Screenshot 2020-03-11 at 19 59 42](https://user-images.githubusercontent.com/4479918/76448851-b1c5c900-63d3-11ea-9ac4-3e2f63560688.png)
