### PR TITLE
Offline Payments Copy Fixes

### DIFF
--- a/resources/views/ManageEvent/Modals/CancelAttendee.blade.php
+++ b/resources/views/ManageEvent/Modals/CancelAttendee.blade.php
@@ -9,9 +9,11 @@
                     {{ @trans("ManageEvent.cancel_attendee_title", ["cancel" => $attendee->full_name]) }}</h3>
             </div>
             <div class="modal-body">
+                @if ($attendee->order->is_payment_received)
                 <div class="alert alert-warning">
                     @lang("ManageEvent.cancelling_order_will_refund_attendees", ['type' => 'attendee'])
                 </div>
+                @endif
                 <p>
                     {{ @trans("ManageEvent.cancel_description") }}
                 </p>

--- a/resources/views/ManageEvent/Modals/CancelOrder.blade.php
+++ b/resources/views/ManageEvent/Modals/CancelOrder.blade.php
@@ -15,9 +15,11 @@
             </div>
             <div class="modal-body">
                 @if($attendees->count())
+                    @if ($order->is_payment_received)
                     <div class="alert alert-warning">
                         @lang("ManageEvent.cancelling_order_will_refund_attendees", ['type' => 'order'])
                     </div>
+                    @endif
                     <div class="form-errors hidden"></div>
                     <div class="help-block">
                         @lang("ManageEvent.select_attendee_to_cancel")

--- a/routes/web.php
+++ b/routes/web.php
@@ -381,19 +381,19 @@ Route::group(
                 [EventAttendeesController::class, 'postMessageAttendees']
             )->name('postMessageAttendees');
 
-            Route::get('{event_id}/attendees/single_message',
+            Route::get('{attendee_id}/attendees/single_message',
                 [EventAttendeesController::class, 'showMessageAttendee']
             )->name('showMessageAttendee');
 
-            Route::post('{event_id}/attendees/single_message',
+            Route::post('{attendee_id}/attendees/single_message',
                 [EventAttendeesController::class, 'postMessageAttendee']
             )->name('postMessageAttendee');
 
-            Route::get('{event_id}/attendees/resend_ticket',
+            Route::get('{attendee_id}/attendees/resend_ticket',
                 [EventAttendeesController::class, 'showResendTicketToAttendee']
             )->name('showResendTicketToAttendee');
 
-            Route::post('{event_id}/attendees/resend_ticket',
+            Route::post('{attendee_id}/attendees/resend_ticket',
                 [EventAttendeesController::class, 'postResendTicketToAttendee']
             )->name('postResendTicketToAttendee');
 


### PR DESCRIPTION
## Context 

If a user selects offline payment when checking out, when you go to the event orders page and click on cancel at the top it says `Cancelling the order will refund the selected attendees`. We shouldn’t show that message for orders which are awaiting payment.

This also counts for cancelling an attendee.

### Changes

- Fixed a couple of named route parameter regressions
- Updated the cancel order to hide refund information if the order used offline payment method
- Updated the cancel attendee to hide refund information if the order used offline payment method

### Screenshots
![Screenshot 2020-04-02 at 16 20 33](https://user-images.githubusercontent.com/4479918/78262013-44074b80-7500-11ea-85e3-ff78a867bd2c.png)
![Screenshot 2020-04-02 at 16 20 42](https://user-images.githubusercontent.com/4479918/78262015-45d10f00-7500-11ea-8d93-6a611de999f1.png)
![Screenshot 2020-04-02 at 16 20 51](https://user-images.githubusercontent.com/4479918/78262017-4669a580-7500-11ea-87a1-4f75f5513053.png)
![Screenshot 2020-04-02 at 16 28 02](https://user-images.githubusercontent.com/4479918/78262020-47023c00-7500-11ea-9a24-4ee9237e2eda.png)
![Screenshot 2020-04-02 at 16 28 07](https://user-images.githubusercontent.com/4479918/78262022-479ad280-7500-11ea-8c75-41442f4a1c7b.png)
