### PR TITLE
General regression fixes after laravel 6 upgrade

### DIFF
--- a/app/Exports/AttendeesExport.php
+++ b/app/Exports/AttendeesExport.php
@@ -2,15 +2,16 @@
 
 namespace App\Exports;
 
-use App\Models\Order;
+use App\Models\Attendee;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Auth;
 use DB;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\BeforeExport;
 
-class OrdersExport implements FromQuery, WithHeadings, WithEvents
+class AttendeesExport implements FromQuery, WithHeadings, WithEvents
 {
     use Exportable;
 
@@ -26,19 +27,22 @@ class OrdersExport implements FromQuery, WithHeadings, WithEvents
     {
         $yes = strtoupper(trans("basic.yes"));
         $no = strtoupper(trans("basic.no"));
-
-        $query = Order::query()->where('event_id', $this->event_id);
-        $query->select([
-            'orders.first_name',
-            'orders.last_name',
-            'orders.email',
+        $query = Attendee::query()->select([
+            'attendees.first_name',
+            'attendees.last_name',
+            'attendees.email',
+            'attendees.private_reference_number',
             'orders.order_reference',
-            'orders.amount',
-            DB::raw("(CASE WHEN orders.is_refunded = 1 THEN '$yes' ELSE '$no' END) AS `orders.is_refunded`"),
-            DB::raw("(CASE WHEN orders.is_partially_refunded = 1 THEN '$yes' ELSE '$no' END) AS `orders.is_partially_refunded`"),
-            'orders.amount_refunded',
+            'tickets.title',
             'orders.created_at',
-        ]);
+            DB::raw("(CASE WHEN attendees.has_arrived THEN '$yes' ELSE '$no' END) AS has_arrived"),
+            'attendees.arrival_time',
+        ])->join('events', 'events.id', '=', 'attendees.event_id')
+            ->join('orders', 'orders.id', '=', 'attendees.order_id')
+            ->join('tickets', 'tickets.id', '=', 'attendees.ticket_id')
+            ->where('attendees.event_id', $this->event_id)
+            ->where('attendees.account_id', Auth::user()->account_id)
+            ->where('attendees.is_cancelled', false);
 
         return $query;
     }
@@ -49,12 +53,12 @@ class OrdersExport implements FromQuery, WithHeadings, WithEvents
             trans("Attendee.first_name"),
             trans("Attendee.last_name"),
             trans("Attendee.email"),
+            trans("Ticket.id"),
             trans("Order.order_ref"),
-            trans("Order.amount"),
-            trans("Order.fully_refunded"),
-            trans("Order.partially_refunded"),
-            trans("Order.amount_refunded"),
+            trans("Ticket.ticket_type"),
             trans("Order.order_date"),
+            trans("Attendee.has_arrived"),
+            trans("Attendee.arrival_time"),
         ];
     }
 

--- a/app/Exports/OrdersExport.php
+++ b/app/Exports/OrdersExport.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Exports;
+
+use App\Models\Order;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use DB;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\BeforeExport;
+use Maatwebsite\Excel\Events\AfterSheet;
+
+class OrdersExport implements FromQuery, WithHeadings, WithEvents
+{
+    use Exportable;
+
+    public function __construct(int $event_id)
+    {
+        $this->event_id = $event_id;
+    }
+
+    /**
+    * @return \Illuminate\Support\Query
+    */
+    public function query()
+    {
+        $yes = strtoupper(trans("basic.yes"));
+        $no = strtoupper(trans("basic.no"));
+
+        $query = Order::query()->where('event_id', $this->event_id);
+        $query->select([
+            'orders.first_name',
+            'orders.last_name',
+            'orders.email',
+            'orders.order_reference',
+            'orders.amount',
+            DB::raw("(CASE WHEN orders.is_refunded = 1 THEN '$yes' ELSE '$no' END) AS `orders.is_refunded`"),
+            DB::raw("(CASE WHEN orders.is_partially_refunded = 1 THEN '$yes' ELSE '$no' END) AS `orders.is_partially_refunded`"),
+            'orders.amount_refunded',
+            'orders.created_at',
+        ]);
+
+        return $query;
+    }
+
+    public function headings(): array
+    {
+        return [
+            trans("Attendee.first_name"),
+            trans("Attendee.last_name"),
+            trans("Attendee.email"),
+            trans("Order.order_ref"),
+            trans("Order.amount"),
+            trans("Order.fully_refunded"),
+            trans("Order.partially_refunded"),
+            trans("Order.amount_refunded"),
+            trans("Order.order_date"),
+        ];
+    }
+
+     /**
+     * @return array
+     */
+    public function registerEvents(): array
+    {
+        return [
+            BeforeExport::class => function(BeforeExport $event) {
+                $event->writer->getProperties()->setCreator(config('attendize.app_name'));
+                $event->writer->getProperties()->setCompany(config('attendize.app_name'));
+            },
+        ];
+    }
+}

--- a/app/Http/Controllers/EventAttendeesController.php
+++ b/app/Http/Controllers/EventAttendeesController.php
@@ -2,6 +2,7 @@
 
 use App\Cancellation\OrderCancellation;
 use App\Exports\AttendeesExport;
+use App\Imports\AttendeesImport;
 use App\Jobs\GenerateTicket;
 use App\Jobs\SendAttendeeInvite;
 use App\Jobs\SendAttendeeTicket;
@@ -286,101 +287,17 @@ class EventAttendeesController extends MyBaseController
 
         }
 
-        $ticket_id = $request->get('ticket_id');
         $event = Event::findOrFail($event_id);
-        $ticket_price = 0;
-        $email_attendee = $request->get('email_ticket');
-        $num_added = 0;
+        $ticket = Ticket::scope()->find($request->get('ticket_id'));
+        $emailAttendees = $request->get('email_ticket');
         if ($request->file('attendees_list')) {
-
-            $the_file = Excel::load($request->file('attendees_list')->getRealPath(), function ($reader) {
-            })->get();
-
-            // Loop through
-            foreach ($the_file as $rows) {
-                if (!empty($rows['first_name']) && !empty($rows['last_name']) && !empty($rows['email'])) {
-                    $num_added++;
-                    $attendee_first_name = strip_tags($rows['first_name']);
-                    $attendee_last_name = strip_tags($rows['last_name']);
-                    $attendee_email = $rows['email'];
-
-                    error_log($ticket_id . ' ' . $ticket_price . ' ' . $email_attendee);
-
-
-                    /**
-                     * Create the order
-                     */
-                    $order = new Order();
-                    $order->first_name = $attendee_first_name;
-                    $order->last_name = $attendee_last_name;
-                    $order->email = $attendee_email;
-                    $order->order_status_id = config('attendize.order.complete');
-                    $order->amount = $ticket_price;
-                    $order->account_id = Auth::user()->account_id;
-                    $order->event_id = $event_id;
-
-                    // Calculating grand total including tax
-                    $orderService = new OrderService($ticket_price, 0, $event);
-                    $orderService->calculateFinalCosts();
-                    $order->taxamt = $orderService->getTaxAmount();
-
-                    if ($orderService->getGrandTotal() == 0) {
-                        $order->is_payment_received = 1;
-                    }
-
-                    $order->save();
-
-                    /**
-                     * Update qty sold
-                     */
-                    $ticket = Ticket::scope()->find($ticket_id);
-                    $ticket->increment('quantity_sold');
-                    $ticket->increment('sales_volume', $ticket_price);
-                    $ticket->event->increment('sales_volume', $ticket_price);
-
-                    /**
-                     * Insert order item
-                     */
-                    $orderItem = new OrderItem();
-                    $orderItem->title = $ticket->title;
-                    $orderItem->quantity = 1;
-                    $orderItem->order_id = $order->id;
-                    $orderItem->unit_price = $ticket_price;
-                    $orderItem->save();
-
-                    /**
-                     * Update the event stats
-                     */
-                    $event_stats = new EventStats();
-                    $event_stats->updateTicketsSoldCount($event_id, 1);
-                    $event_stats->updateTicketRevenue($ticket_id, $ticket_price);
-
-                    /**
-                     * Create the attendee
-                     */
-                    $attendee = new Attendee();
-                    $attendee->first_name = $attendee_first_name;
-                    $attendee->last_name = $attendee_last_name;
-                    $attendee->email = $attendee_email;
-                    $attendee->event_id = $event_id;
-                    $attendee->order_id = $order->id;
-                    $attendee->ticket_id = $ticket_id;
-                    $attendee->account_id = Auth::user()->account_id;
-                    $attendee->reference_index = 1;
-                    $attendee->save();
-
-                    if ($email_attendee == '1') {
-                        $this->dispatch(new SendAttendeeInvite($attendee));
-                    }
-                }
-            };
+            (new AttendeesImport($event, $ticket, (bool)$emailAttendees))->import(request()->file('attendees_list'));
         }
 
-        session()->flash('message', $num_added . ' Attendees Successfully Invited');
+        session()->flash('message', 'Attendees Successfully Invited');
 
         return response()->json([
             'status'      => 'success',
-            'id'          => $attendee->id,
             'redirectUrl' => route('showEventAttendees', [
                 'event_id' => $event_id,
             ]),

--- a/app/Http/Controllers/EventAttendeesController.php
+++ b/app/Http/Controllers/EventAttendeesController.php
@@ -1,6 +1,7 @@
 <?php namespace App\Http\Controllers;
 
 use App\Cancellation\OrderCancellation;
+use App\Exports\AttendeesExport;
 use App\Jobs\GenerateTicket;
 use App\Jobs\SendAttendeeInvite;
 use App\Jobs\SendAttendeeTicket;
@@ -567,59 +568,9 @@ class EventAttendeesController extends MyBaseController
      */
     public function showExportAttendees($event_id, $export_as = 'xls')
     {
-
-        Excel::create('attendees-as-of-' . date('d-m-Y-g.i.a'), function ($excel) use ($event_id) {
-
-            $excel->setTitle('Attendees List');
-
-            // Chain the setters
-            $excel->setCreator(config('attendize.app_name'))
-                ->setCompany(config('attendize.app_name'));
-
-            $excel->sheet('attendees_sheet_1', function ($sheet) use ($event_id) {
-                DB::connection();
-                $data = DB::table('attendees')
-                    ->where('attendees.event_id', '=', $event_id)
-                    ->where('attendees.is_cancelled', '=', 0)
-                    ->where('attendees.account_id', '=', Auth::user()->account_id)
-                    ->join('events', 'events.id', '=', 'attendees.event_id')
-                    ->join('orders', 'orders.id', '=', 'attendees.order_id')
-                    ->join('tickets', 'tickets.id', '=', 'attendees.ticket_id')
-                    ->select([
-                        'attendees.first_name',
-                        'attendees.last_name',
-                        'attendees.email',
-			'attendees.private_reference_number',
-                        'orders.order_reference',
-                        'tickets.title',
-                        'orders.created_at',
-                        DB::raw("(CASE WHEN attendees.has_arrived THEN 'YES' ELSE 'NO' END) AS has_arrived"),
-                        'attendees.arrival_time',
-                    ])->get();
-
-                $data = array_map(function($object) {
-                    return (array)$object;
-                }, $data->toArray());
-
-                $sheet->fromArray($data);
-                $sheet->row(1, [
-                    'First Name',
-                    'Last Name',
-                    'Email',
-		    'Ticket ID',
-                    'Order Reference',
-                    'Ticket Type',
-                    'Purchase Date',
-                    'Has Arrived',
-                    'Arrival Time',
-                ]);
-
-                // Set gray background on first row
-                $sheet->row(1, function ($row) {
-                    $row->setBackground('#f5f5f5');
-                });
-            });
-        })->export($export_as);
+        $event = Event::scope()->findOrFail($event_id);
+        $date = date('d-m-Y-g.i.a');
+        return (new AttendeesExport($event->id))->download("attendees-as-of-{$date}.{$export_as}");
     }
 
     /**

--- a/app/Http/Controllers/EventAttendeesController.php
+++ b/app/Http/Controllers/EventAttendeesController.php
@@ -171,7 +171,6 @@ class EventAttendeesController extends MyBaseController
             $ticket = Ticket::scope()->find($ticket_id);
             $ticket->increment('quantity_sold');
             $ticket->increment('sales_volume', $ticket_price);
-            $ticket->event->increment('sales_volume', $ticket_price);
 
             /*
              * Insert order item

--- a/app/Imports/AttendeesImport.php
+++ b/app/Imports/AttendeesImport.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Imports;
+
+use App\Models\Event;
+use App\Models\EventStats;
+use App\Models\Attendee;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Ticket;
+use Auth;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithHeadingRow;
+use App\Jobs\SendAttendeeInvite;
+use Maatwebsite\Excel\Row;
+use Maatwebsite\Excel\Concerns\OnEachRow;
+
+class AttendeesImport implements OnEachRow, WithHeadingRow
+{
+    use Importable;
+
+    public function __construct(Event $event, Ticket $ticket, bool $emailAttendees)
+    {
+        $this->event = $event;
+        $this->ticket = $ticket;
+        $this->emailAttendees = $emailAttendees;
+    }
+
+    /**
+    * @param array $row
+    *
+    * @return \Illuminate\Database\Eloquent\Model|null
+    */
+    public function onRow(Row $row)
+    {
+        $rowArr = $row->toArray();
+        $firstName = $rowArr['first_name'];
+        $lastName = $rowArr['last_name'];
+        $email = $rowArr['email'];
+
+        \Log::info(sprintf("Importing attendee: %s (%s %s)", $email, $firstName, $lastName));
+
+        // Create a new order for the attendee
+        $order = Order::create([
+            'first_name' => $firstName,
+            'last_name' => $lastName,
+            'email' => $email,
+            'order_status_id' => config('attendize.order.complete'),
+            'amount' => 0,
+            'account_id' => Auth::user()->account_id,
+            'event_id' => $this->event->id,
+            'taxamt' => 0,
+        ]);
+
+        $orderItem = OrderItem::create([
+            'title' => $this->ticket->title,
+            'quantity' => 1,
+            'order_id' => $order->id,
+            'unit_price' => 0,
+        ]);
+
+        // Increment the ticket quantity
+        $this->ticket->increment('quantity_sold');
+        (new EventStats())->updateTicketsSoldCount($this->event->id, 1);
+
+        $attendee = Attendee::create([
+            'first_name' => $firstName,
+            'last_name' => $lastName,
+            'email' => $email,
+            'event_id' => $this->event->id,
+            'order_id' => $order->id,
+            'ticket_id' => $this->ticket->id,
+            'account_id' => Auth::user()->account_id,
+            'reference_index' => 1,
+        ]);
+
+        if ($this->emailAttendees) {
+            dispatch(new SendAttendeeInvite($attendee));
+        }
+
+        return $attendee;
+    }
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -26,6 +26,20 @@ class Order extends MyBaseModel
     ];
 
     /**
+     * @var array $fillable
+     */
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'email',
+        'order_status_id',
+        'amount',
+        'account_id',
+        'event_id',
+        'taxamt',
+    ];
+
+    /**
      * The validation error messages.
      *
      * @var array $messages

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -19,4 +19,14 @@ class OrderItem extends MyBaseModel
      * @var bool $timestamps
      */
     public $timestamps = false;
+
+    /**
+     * @var array $fillable
+     */
+    protected $fillable = [
+        'title',
+        'quantity',
+        'order_id',
+        'unit_price',
+    ];
 }

--- a/config/app.php
+++ b/config/app.php
@@ -174,6 +174,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        Maatwebsite\Excel\ExcelServiceProvider::class,
 
         /*
          * Attendize Service Providers
@@ -238,7 +239,7 @@ return [
         'Markdown'     => GrahamCampbell\Markdown\Facades\Markdown::class,
         'PDF'          => Nitmedia\Wkhtml2pdf\Facades\Wkhtml2pdf::class,
         'Utils'        => App\Attendize\Utils::class,
-
+        'Excel'        => Maatwebsite\Excel\Facades\Excel::class,
     ],
 
 ];

--- a/resources/lang/en/Attendee.php
+++ b/resources/lang/en/Attendee.php
@@ -7,6 +7,8 @@ return array (
   //============================== New strings to translate ==============================//
   'scan_another_ticket' => 'Scan Another Ticket',
   'scanning' => 'Scanning',
+  'has_arrived' => 'Has Arrived',
+  'arrival_time' => 'Arrival Time',
   //==================================== Translations ====================================//
   'attendees' => 'Attendees',
   'check_in' => 'Check in: :event',

--- a/resources/lang/en/Ticket.php
+++ b/resources/lang/en/Ticket.php
@@ -4,6 +4,7 @@ return array (
   //============================== New strings to translate ==============================//
   // Defined in file C:\\wamp\\www\\attendize\\resources\\views\\ManageEvent\\Tickets.blade.php
   'on_sale' => 'On Sale',
+  'id' => 'Ticket ID',
   //==================================== Translations ====================================//
   'attendee_ref' => 'Attendee Ref.',
   'coupon_codes' => 'Coupon Codes',

--- a/resources/views/ManageOrganiser/Customize.blade.php
+++ b/resources/views/ManageOrganiser/Customize.blade.php
@@ -197,7 +197,7 @@
                     {!! Form::close() !!}
                 </div>
                 <div class="tab-pane scale_iframe" id="OrganiserPageDesign">
-                    {!! Form::model($organiser, array('url' => route('postEditOrganiserPageDesign', ['event_id' => $organiser->id]), 'class' => 'ajax ')) !!}
+                    {!! Form::model($organiser, array('url' => route('postEditOrganiserPageDesign', ['organiser_id' => $organiser->id]), 'class' => 'ajax ')) !!}
 
                     <div class="row">
 


### PR DESCRIPTION
# Summary

There has been some regressions with the laravel 6 upgrade so here is a PR to fix the niggles as they got found during the last rounds of testing `next`.

## Changes

- Fixed the regression for `Excel` exports not working. [The version bump was a breaking change](https://docs.laravel-excel.com/3.1/getting-started/upgrade.html#upgrading-to-3-from-2-1)
- Removed the `sales_volume` increment on the `events` table since the field does not exist anymore
- Added back the `Excel` facade alias and service provider
- Added new translated strings for export columns
- Fixed the Organizer customize UI that had a failed route parameter in due to copy pasta
- Fixed the attendee bulk invite importer


### Screenshots

**Orders Export**
![Screenshot 2020-04-05 at 13 44 14](https://user-images.githubusercontent.com/4479918/78473786-95534d00-7743-11ea-9f57-d0c100156fd4.png)

**Attendees Export**
![Screenshot 2020-04-05 at 13 45 49](https://user-images.githubusercontent.com/4479918/78473817-c92e7280-7743-11ea-9b7f-bbc5a8185e7e.png)
