### PR TITLE
Update ManageAccountController.php

### DIFF
--- a/app/Http/Controllers/ManageAccountController.php
+++ b/app/Http/Controllers/ManageAccountController.php
@@ -22,7 +22,6 @@ use Illuminate\Support\Str;
 use Services\PaymentGateway\Dummy;
 use Services\PaymentGateway\Stripe;
 use Services\PaymentGateway\StripeSCA;
-use Validator;
 use Utils;
 
 class ManageAccountController extends MyBaseController


### PR DESCRIPTION
Corrected 500 internal server error in accessing Account Settings in top right dropdown options, caused by Validator being used when already in use within the same controller (app/Http/Controllers/ManageAccouuntController.php). No problems seem to be caused by this fix in my testing.