### PR TITLE
Moved user api closure to controller to allow usage of php artisan route:cache

### DIFF
--- a/app/Http/Controllers/API/UserApiController.php
+++ b/app/Http/Controllers/API/UserApiController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use Illuminate\Http\Request;
+
+class UserApiController extends ApiBaseController
+{
+
+    /**
+     * @param Request $request
+     * @return mixed
+     */
+    public function get(Request $request)
+    {
+        return $request->user();
+    }
+
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,9 +13,7 @@ use Illuminate\Http\Request;
 |
 */
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
+Route::middleware('auth:api')->get('/user', [API\UserApiController::class, 'get']);
 
 /*
  * ---------------


### PR DESCRIPTION
[Laravel documentation on deployment suggests optimizations using caching routes](https://laravel.com/docs/8.x/deployment#optimizing-route-loading), but it doesn't work with closure routes so I moved the only closure route in the project to controllers.
