### PR TITLE
PHP header method which is used by Wkhtml2pdf lib to download file doesn't work when using swoole; replaced with laravel response

### DIFF
--- a/app/Http/Controllers/EventAttendeesController.php
+++ b/app/Http/Controllers/EventAttendeesController.php
@@ -23,6 +23,7 @@ use Exception;
 use Illuminate\Http\Request;
 use Log;
 use Mail;
+use Nitmedia\Wkhtml2pdf\Wkhtml2pdf;
 use PDF;
 use Validator;
 
@@ -707,7 +708,13 @@ class EventAttendeesController extends MyBaseController
         ];
 
         if ($request->get('download') == '1') {
-            return PDF::html('Public.ViewEvent.Partials.PDFTicket', $data, 'Tickets');
+            $pdfName = $attendee->order->order_reference . '-' . $attendee_id . '-tickets';
+            $pdfPath = join(DIRECTORY_SEPARATOR, [storage_path(), 'app', $pdfName]);
+            PDF::setOutputMode(Wkhtml2pdf::MODE_SAVE);
+            PDF::html('Public.ViewEvent.Partials.PDFTicket', $data, $pdfPath);
+            return response()->download($pdfPath . '.pdf', $pdfName . '.pdf', [
+                'Content-Type' => 'application/pdf'
+            ])->deleteFileAfterSend(true);
         }
         return view('Public.ViewEvent.Partials.PDFTicket', $data);
     }

--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -27,6 +27,7 @@ use DB;
 use Illuminate\Http\Request;
 use Log;
 use Mail;
+use Nitmedia\Wkhtml2pdf\Wkhtml2pdf;
 use Omnipay;
 use PDF;
 use PhpSpec\Exception\Exception;
@@ -814,7 +815,13 @@ class EventCheckoutController extends Controller
         ];
 
         if ($request->get('download') == '1') {
-            return PDF::html('Public.ViewEvent.Partials.PDFTicket', $data, 'Tickets');
+            $pdfName = $order_reference . '-tickets';
+            $pdfPath = join(DIRECTORY_SEPARATOR, [storage_path(), 'app', $pdfName]);
+            PDF::setOutputMode(Wkhtml2pdf::MODE_SAVE);
+            PDF::html('Public.ViewEvent.Partials.PDFTicket', $data, $pdfPath);
+            return response()->download($pdfPath . '.pdf', $pdfName . '.pdf', [
+                'Content-Type' => 'application/pdf'
+            ])->deleteFileAfterSend(true);
         }
         return view('Public.ViewEvent.Partials.PDFTicket', $data);
     }


### PR DESCRIPTION
So I was pushing this service to its limits and last thing I could do is to try using swoole with it. And it worked, mostly. Only thing I found broken is tickets downloading since Wkhtml2pdf uses header method that isn't supported by swoole. So here is a fix which works with and without swoole just by using laravel response object.