### PR TITLE
added locale prefix to email templates calls inside controllers

### DIFF
--- a/app/Http/Controllers/EventAttendeesController.php
+++ b/app/Http/Controllers/EventAttendeesController.php
@@ -25,6 +25,7 @@ use Log;
 use Mail;
 use PDF;
 use Validator;
+use Illuminate\Support\Facades\Lang;
 
 class EventAttendeesController extends MyBaseController
 {
@@ -371,7 +372,7 @@ class EventAttendeesController extends MyBaseController
         ];
 
         //@todo move this to the SendAttendeeMessage Job
-        Mail::send('Emails.messageReceived', $data, function ($message) use ($attendee, $data) {
+        Mail::send(Lang::locale().'.Emails.messageReceived', $data, function ($message) use ($attendee, $data) {
             $message->to($attendee->email, $attendee->full_name)
                 ->from(config('attendize.outgoing_email_noreply'), $attendee->event->organiser->name)
                 ->replyTo($attendee->event->organiser->email, $attendee->event->organiser->name)
@@ -380,7 +381,7 @@ class EventAttendeesController extends MyBaseController
 
         /* Could bcc in the above? */
         if ($request->get('send_copy') == '1') {
-            Mail::send('Emails.messageReceived', $data, function ($message) use ($attendee, $data) {
+            Mail::send(Lang::locale().'.Emails.messageReceived', $data, function ($message) use ($attendee, $data) {
                 $message->to($attendee->event->organiser->email, $attendee->event->organiser->name)
                     ->from(config('attendize.outgoing_email_noreply'), $attendee->event->organiser->name)
                     ->replyTo($attendee->event->organiser->email, $attendee->event->organiser->name)
@@ -612,7 +613,7 @@ class EventAttendeesController extends MyBaseController
 
         if ($request->get('notify_attendee') == '1') {
             try {
-                Mail::send('Emails.notifyCancelledAttendee', $data, function ($message) use ($attendee) {
+                Mail::send(Lang::locale().'.Emails.notifyCancelledAttendee', $data, function ($message) use ($attendee) {
                     $message->to($attendee->email, $attendee->full_name)
                         ->from(config('attendize.outgoing_email_noreply'), $attendee->event->organiser->name)
                         ->replyTo($attendee->event->organiser->email, $attendee->event->organiser->name)
@@ -626,7 +627,7 @@ class EventAttendeesController extends MyBaseController
 
         try {
             // Let the user know that they have received a refund.
-            Mail::send('Emails.notifyRefundedAttendee', $data, function ($message) use ($attendee) {
+            Mail::send(Lang::locale().'.Emails.notifyRefundedAttendee', $data, function ($message) use ($attendee) {
                 $message->to($attendee->email, $attendee->full_name)
                     ->from(config('attendize.outgoing_email_noreply'), $attendee->event->organiser->name)
                     ->replyTo($attendee->event->organiser->email, $attendee->event->organiser->name)

--- a/app/Http/Controllers/EventOrdersController.php
+++ b/app/Http/Controllers/EventOrdersController.php
@@ -16,6 +16,7 @@ use Log;
 use Mail;
 use Session;
 use Validator;
+use Illuminate\Support\Facades\Lang;
 
 class EventOrdersController extends MyBaseController
 {
@@ -306,7 +307,7 @@ class EventOrdersController extends MyBaseController
             'email_logo'      => $order->event->organiser->full_logo_path,
         ];
 
-        Mail::send('Emails.messageReceived', $data, function ($message) use ($order, $data) {
+        Mail::send(Lang::locale().'.Emails.messageReceived', $data, function ($message) use ($order, $data) {
             $message->to($order->email, $order->full_name)
                 ->from(config('attendize.outgoing_email_noreply'), $order->event->organiser->name)
                 ->replyTo($order->event->organiser->email, $order->event->organiser->name)
@@ -315,7 +316,7 @@ class EventOrdersController extends MyBaseController
 
         /* Send a copy to the Organiser with a different subject */
         if ($request->get('send_copy') == '1') {
-            Mail::send('Emails.messageReceived', $data, function ($message) use ($order, $data) {
+            Mail::send(Lang::locale().'.Emails.messageReceived', $data, function ($message) use ($order, $data) {
                 $message->to($order->event->organiser->email)
                     ->from(config('attendize.outgoing_email_noreply'), $order->event->organiser->name)
                     ->replyTo($order->event->organiser->email, $order->event->organiser->name)

--- a/app/Http/Controllers/EventViewController.php
+++ b/app/Http/Controllers/EventViewController.php
@@ -14,6 +14,7 @@ use Mail;
 use Redirect;
 use Validator;
 use Services\Captcha\Factory;
+use Illuminate\Support\Facades\Lang;
 
 class EventViewController extends Controller
 {
@@ -133,7 +134,7 @@ class EventViewController extends Controller
             'event'           => $event,
         ];
 
-        Mail::send('Emails.messageReceived', $data, function ($message) use ($event, $data) {
+        Mail::send(Lang::locale().'.Emails.messageReceived', $data, function ($message) use ($event, $data) {
             $message->to($event->organiser->email, $event->organiser->name)
                 ->from(config('attendize.outgoing_email_noreply'), $data['sender_name'])
                 ->replyTo($data['sender_email'], $data['sender_name'])

--- a/app/Http/Controllers/ManageAccountController.php
+++ b/app/Http/Controllers/ManageAccountController.php
@@ -23,6 +23,7 @@ use Services\PaymentGateway\Dummy;
 use Services\PaymentGateway\Stripe;
 use Services\PaymentGateway\StripeSCA;
 use Utils;
+use Illuminate\Support\Facades\Lang;
 
 class ManageAccountController extends MyBaseController
 {
@@ -200,7 +201,7 @@ class ManageAccountController extends MyBaseController
             'inviter'       => Auth::user(),
         ];
 
-        Mail::send('Emails.inviteUser', $data, static function (Message $message) use ($data) {
+        Mail::send(Lang::locale().'.Emails.inviteUser', $data, static function (Message $message) use ($data) {
             $message->to($data['user']->email)
                 ->subject(trans('Email.invite_user', [
                     'name' => $data['inviter']->first_name . ' ' . $data['inviter']->last_name,

--- a/app/Http/Controllers/UserSignupController.php
+++ b/app/Http/Controllers/UserSignupController.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Http\Request;
 use Mail;
 use Services\Captcha\Factory;
+use Illuminate\Support\Facades\Lang;
 
 class UserSignupController extends Controller
 {
@@ -80,7 +81,7 @@ class UserSignupController extends Controller
 
         if ($is_attendize) {
             // TODO: Do this async?
-            Mail::send('Emails.ConfirmEmail',
+            Mail::send(Lang::locale().'.Emails.ConfirmEmail',
                 ['first_name' => $user->first_name, 'confirmation_code' => $user->confirmation_code],
                 function ($message) use ($request) {
                     $message->to($request->get('email'), $request->get('first_name'))


### PR DESCRIPTION
This PR adds much needed prefixes inside controllers to use locale-specific email templates. Without it, all emails are sent in English