### PR TITLE
fix: missing order images will cause ticket generation failure

### DIFF
--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -800,7 +800,12 @@ class EventCheckoutController extends Controller
         $images = [];
         $imgs = $order->event->images;
         foreach ($imgs as $img) {
-            $images[] = base64_encode(file_get_contents(public_path($img->image_path)));
+            $order_image_abs_pathname = public_path($img->image_path);
+            if (file_exists($order_image_abs_pathname)) {
+                $images[] = base64_encode(file_get_contents($order_image_abs_pathname));
+            } else {
+                Log::warn(sprintf("Image doesn't exist: `%s`", $order_image_abs_pathname));
+            }
         }
 
         $data = [

--- a/app/Jobs/GenerateTicketsJobBase.php
+++ b/app/Jobs/GenerateTicketsJobBase.php
@@ -39,7 +39,12 @@ class GenerateTicketsJobBase implements ShouldQueue
         $images = [];
         $imgs = $this->event->images;
         foreach ($imgs as $img) {
-            $images[] = base64_encode(file_get_contents(public_path($img->image_path)));
+            $event_image_abs_pathname = public_path($img->image_path);
+            if (file_exists($event_image_abs_pathname)) {
+                $images[] = base64_encode(file_get_contents($event_image_abs_pathname));
+            } else {
+                Log::warn(sprintf("Image doesn't exist: `%s`", $event_image_abs_pathname));
+            }
         }
 
         $data = [


### PR DESCRIPTION
If order images were removed from disk ticket but still present in the database generation will fail silently.

solution: render ticket even if images are missing and log the error