### PR TITLE
Make ticket holder email optional

### DIFF
--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -727,7 +727,7 @@ class EventCheckoutController extends Controller
         // Send tickets to attendees
         Log::debug('Queueing Attendee Ticket Jobs');
         foreach ($order->attendees as $attendee) {
-            if (isset($attendee->email) && $attendee->email !== $order->email) {
+            if (isset($attendee->email) && !empty($attendee->email) && $attendee->email !== $order->email) {
                 SendOrderAttendeeTicketJob::dispatch($attendee);
                 Log::debug('Queueing Attendee Ticket Job Done');
             }

--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -159,11 +159,10 @@ class EventCheckoutController extends Controller
                  */
                 $validation_rules['ticket_holder_first_name.' . $i . '.' . $ticket_id] = ['required'];
                 $validation_rules['ticket_holder_last_name.' . $i . '.' . $ticket_id] = ['required'];
-                $validation_rules['ticket_holder_email.' . $i . '.' . $ticket_id] = ['required', 'email'];
+                $validation_rules['ticket_holder_email.' . $i . '.' . $ticket_id] = ['nullable', 'email'];
 
                 $validation_messages['ticket_holder_first_name.' . $i . '.' . $ticket_id . '.required'] = 'Ticket holder ' . ($i + 1) . '\'s first name is required';
                 $validation_messages['ticket_holder_last_name.' . $i . '.' . $ticket_id . '.required'] = 'Ticket holder ' . ($i + 1) . '\'s last name is required';
-                $validation_messages['ticket_holder_email.' . $i . '.' . $ticket_id . '.required'] = 'Ticket holder ' . ($i + 1) . '\'s email is required';
                 $validation_messages['ticket_holder_email.' . $i . '.' . $ticket_id . '.email'] = 'Ticket holder ' . ($i + 1) . '\'s email appears to be invalid';
 
                 /*
@@ -728,8 +727,10 @@ class EventCheckoutController extends Controller
         // Send tickets to attendees
         Log::debug('Queueing Attendee Ticket Jobs');
         foreach ($order->attendees as $attendee) {
-            SendOrderAttendeeTicketJob::dispatch($attendee);
-            Log::debug('Queueing Attendee Ticket Job Done');
+            if (isset($attendee->email) && $attendee->email !== $order->email) {
+                SendOrderAttendeeTicketJob::dispatch($attendee);
+                Log::debug('Queueing Attendee Ticket Job Done');
+            }
         }
 
         if ($return_json) {

--- a/resources/views/Public/ViewEvent/Partials/EventCreateOrderSection.blade.php
+++ b/resources/views/Public/ViewEvent/Partials/EventCreateOrderSection.blade.php
@@ -195,7 +195,7 @@
                                             <div class="col-md-12">
                                                 <div class="form-group">
                                                     {!! Form::label("ticket_holder_email[{$i}][{$ticket['ticket']['id']}]", trans("Public_ViewEvent.email_address")) !!}
-                                                    {!! Form::text("ticket_holder_email[{$i}][{$ticket['ticket']['id']}]", null, ['required' => 'required', 'class' => "ticket_holder_email.$i.{$ticket['ticket']['id']} ticket_holder_email form-control"]) !!}
+                                                    {!! Form::text("ticket_holder_email[{$i}][{$ticket['ticket']['id']}]", null, ['class' => "ticket_holder_email.$i.{$ticket['ticket']['id']} ticket_holder_email form-control"]) !!}
                                                 </div>
                                             </div>
                                             @include('Public.ViewEvent.Partials.AttendeeQuestions', ['ticket' => $ticket['ticket'],'attendee_number' => $total_attendee_increment++])


### PR DESCRIPTION
There are times you don't want to send tickets to everyone, attendize allows entering same email but this would cause you to receive all email which is also not ideal.