### PR TITLE
Add file upload question, validation, storage, and preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=https://localhost:8081
 
+FILE_UPLOAD_MIMETYPE = mimetypes:application/pdf
+
 LOG_CHANNEL=stack
 
 DB_CONNECTION=mysql

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use App\Jobs\RemoveOldTempFiles;
 
 class Kernel extends ConsoleKernel
 {
@@ -25,6 +26,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
+        $schedule->job(new RemoveOldTempFiles)->everyThirtyMinutes();
     }
 
     /**

--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -362,24 +362,26 @@ class EventCheckoutController extends Controller
                 'messages' => $order->errors(),
             ]);
         }
-
-        // All files are validated, now remove file objects from array to avoid serialization errors
-        // Files are stored in a temp folder, awaiting order confirmation
-        $order_hash_data = microtime().random_bytes(10);
-        // take only the first 20 characters, it would take 16^20 bruteforce requests
-        $folder_name = substr(hash('sha256', $order_hash_data), 0, 20);
-        $order_dir_path = 'docs/'.$folder_name;
-        //File::makeDirectory($order_dir_path);
-        foreach($request_data['ticket_holder_files'] as $key => $ticket)
+        if(isset($request_data['ticket_holder_files']))
         {
-            foreach($ticket as $i=>$item)
+            // All files are validated, now remove file objects from array to avoid serialization errors
+            // Files are stored in a temp folder, awaiting order confirmation
+            $order_hash_data = microtime().random_bytes(10);
+            // take only the first 20 characters, it would take 16^20 bruteforce requests
+            $folder_name = substr(hash('sha256', $order_hash_data), 0, 20);
+            $order_dir_path = 'docs/'.$folder_name;
+            //File::makeDirectory($order_dir_path);
+            foreach($request_data['ticket_holder_files'] as $key => $ticket)
             {
-                foreach($item as $question_id => $file)
+                foreach($ticket as $i=>$item)
                 {
-                    if(isset($file)) {
-                        // Store the file in a temporary folder, use Laravel default file name
-                        $path = $file->store("tmp/$order_dir_path");
-                        $request_data['ticket_holder_files'][$key][$i][$question_id] = $path;
+                    foreach($item as $question_id => $file)
+                    {
+                        if(isset($file)) {
+                            // Store the file in a temporary folder, use Laravel default file name
+                            $path = $file->store("tmp/$order_dir_path");
+                            $request_data['ticket_holder_files'][$key][$i][$question_id] = $path;
+                        }
                     }
                 }
             }

--- a/app/Http/Controllers/EventCheckoutController.php
+++ b/app/Http/Controllers/EventCheckoutController.php
@@ -24,7 +24,11 @@ use Carbon\Carbon;
 use Config;
 use Cookie;
 use DB;
+use File;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator as FacadesValidator;
 use Log;
 use Mail;
 use Omnipay;
@@ -169,10 +173,29 @@ class EventCheckoutController extends Controller
                 /*
                  * Validation rules for custom questions
                  */
+
                 foreach ($ticket->questions as $question) {
-                    if ($question->is_required && $question->is_enabled) {
-                        $validation_rules['ticket_holder_questions.' . $ticket_id . '.' . $i . '.' . $question->id] = ['required'];
-                        $validation_messages['ticket_holder_questions.' . $ticket_id . '.' . $i . '.' . $question->id . '.required'] = "This question is required";
+                    if ($question->is_enabled) {
+                        // If question is a file upload
+                        if($question->question_type_id == Config::get('attendize.question_file_single')) {
+                            $mimetype = env('FILE_UPLOAD_MIMETYPE');
+                            $question_id = $question->id;
+                            if($question->is_required) {
+                                $validation_rules["ticket_holder_files.$ticket_id.$i.$question_id"] = ['required', $mimetype, 'max:2048'];
+                                $validation_messages["ticket_holder_files.$ticket_id.$i.$question_id.required"] = 'You have to select a file';
+                                $validation_messages["ticket_holder_files.$ticket_id.$i.$question_id.mimetypes"] = 'Your file is not of the correct type';
+                            }
+                            else {
+                                $validation_rules["ticket_holder_files.$ticket_id.$i.$question_id"] = ['max:2048'];
+                            }
+
+                            $validation_messages["ticket_holder_files.$ticket_id.$i.$question_id.max"] = 'Your file is too large (max 2Mb)';
+                        }
+                        // Otherwise use standard validation rules
+                        else if($question->is_required) {
+                            $validation_rules['ticket_holder_questions.' . $ticket_id . '.' . $i . '.' . $question->id] = ['required'];
+                            $validation_messages['ticket_holder_questions.' . $ticket_id . '.' . $i . '.' . $question->id . '.required'] = "This question is required";
+                        }
                     }
                 }
             }
@@ -291,18 +314,22 @@ class EventCheckoutController extends Controller
         }
 
         $request_data = session()->get('ticket_order_' . $event_id . ".request_data");
-        $request_data = (!empty($request_data[0])) ? array_merge($request_data[0], $request->all())
-                                                   : $request->all();
 
-        session()->remove('ticket_order_' . $event_id . '.request_data');
-        session()->push('ticket_order_' . $event_id . '.request_data', $request_data);
+        // Check for files in answers and treat them
+        /**
+         * Files objects are stored in 'ticket_holder_files' : they are then stored 
+         * and their path is put into ticket_holder_answers 
+         */
+        $new_request_data = $request->all();
 
-        $event = Event::findOrFail($event_id);
-        $order = new Order();
         $ticket_order = session()->get('ticket_order_' . $event_id);
 
         $validation_rules = $ticket_order['validation_rules'];
         $validation_messages = $ticket_order['validation_messages'];
+
+        $request_data = (!empty($request_data[0])) ? array_merge($request_data[0], $new_request_data)
+                                                   : $new_request_data;
+        $order = new Order();
 
         $order->rules = $order->rules + $validation_rules;
         $order->messages = $order->messages + $validation_messages;
@@ -329,12 +356,37 @@ class EventCheckoutController extends Controller
             $order->messages = $order->messages + $businessMessages;
         }
 
-        if (!$order->validate($request->all())) {
+        if (!$order->validate($new_request_data)) {
             return response()->json([
                 'status'   => 'error',
                 'messages' => $order->errors(),
             ]);
         }
+
+        // All files are validated, now remove file objects from array to avoid serialization errors
+        // Files are stored in a temp folder, awaiting order confirmation
+        $order_hash_data = microtime().random_bytes(10);
+        // take only the first 20 characters, it would take 16^20 bruteforce requests
+        $folder_name = substr(hash('sha256', $order_hash_data), 0, 20);
+        $order_dir_path = 'docs/'.$folder_name;
+        //File::makeDirectory($order_dir_path);
+        foreach($request_data['ticket_holder_files'] as $key => $ticket)
+        {
+            foreach($ticket as $i=>$item)
+            {
+                foreach($item as $question_id => $file)
+                {
+                    if(isset($file)) {
+                        // Store the file in a temporary folder, use Laravel default file name
+                        $path = $file->store("tmp/$order_dir_path");
+                        $request_data['ticket_holder_files'][$key][$i][$question_id] = $path;
+                    }
+                }
+            }
+        }
+
+        session()->remove('ticket_order_' . $event_id . '.request_data');
+        session()->push('ticket_order_' . $event_id . '.request_data', $request_data);
 
         return response()->json([
             'status'      => 'success',
@@ -470,7 +522,7 @@ class EventCheckoutController extends Controller
                     'message' => $response->getMessage(),
                 ]);
             }
-        } catch (\Exeption $e) {
+        } catch (\Exception $e) {
             Log::error($e);
             $error = 'Sorry, there was an error processing your payment. Please try again.';
         }
@@ -516,7 +568,6 @@ class EventCheckoutController extends Controller
                 'is_payment_failed' => 1,
             ]);
         }
-
     }
 
     /**
@@ -664,9 +715,32 @@ class EventCheckoutController extends Controller
 
 
                     /*
-                     * Save the attendee's questions
+                     * Save the attendee's questions and move file to a definitive directory
                      */
+
+                    // Generate folder name if there are files to store
+                    // Hide files in a secure way
+                    // Generate sandwich-proof data for the hash (time-based randomness and os-based randomness)
+                    $foldername = null;
+                    if(isset($request_data['ticket_holder_files'])) { 
+                        $file_hash_data = microtime().random_bytes(10);
+                        $foldername = substr(hash('sha256', $file_hash_data), 0, 20);
+                    }
+
                     foreach ($attendee_details['ticket']->questions as $question) {
+                        // If there is a temp file there
+                        if(isset($request_data['ticket_holder_files'][$attendee_details['ticket']->id][$i][$question->id])) {
+                            // Get it's path and generate a new one
+                            $tmp_path = $request_data['ticket_holder_files'][$attendee_details['ticket']->id][$i][$question->id];
+                            $definitive_path = "docs/$foldername/".basename($tmp_path);
+                            // Move the file
+                            Storage::disk('local')->move($tmp_path, $definitive_path);
+                            // Remove the temp directory
+                            Storage::disk('local')->deleteDirectory(dirname($tmp_path));
+                            // Change file path
+                            $ticket_questions[$attendee_details['ticket']->id][$i][$question->id] = $definitive_path;
+                        }
+
                         $ticket_answer = isset($ticket_questions[$attendee_details['ticket']->id][$i][$question->id])
                             ? $ticket_questions[$attendee_details['ticket']->id][$i][$question->id]
                             : null;
@@ -682,14 +756,13 @@ class EventCheckoutController extends Controller
                         $ticket_answer = is_array($ticket_answer) ? implode(', ', $ticket_answer) : $ticket_answer;
 
                         if (!empty($ticket_answer)) {
-                            QuestionAnswer::create([
-                                'answer_text' => $ticket_answer,
-                                'attendee_id' => $attendee->id,
-                                'event_id'    => $event->id,
-                                'account_id'  => $event->account->id,
-                                'question_id' => $question->id
-                            ]);
-
+                            $qa = new QuestionAnswer();
+                            $qa->answer_text = $ticket_answer;
+                            $qa->attendee_id = $attendee->id;
+                            $qa->event_id = $event->id;
+                            $qa->account_id = $event->account->id;
+                            $qa->question_id = $question->id;
+                            $qa->save();
                         }
                     }
 
@@ -697,7 +770,6 @@ class EventCheckoutController extends Controller
                     $attendee_increment++;
                 }
             }
-
         } catch (Exception $e) {
             Log::error($e);
             DB::rollBack();
@@ -746,8 +818,6 @@ class EventCheckoutController extends Controller
             'is_embedded'     => $this->is_embedded,
             'order_reference' => $order->order_reference,
         ]);
-
-
     }
 
     /**
@@ -819,4 +889,16 @@ class EventCheckoutController extends Controller
         return view('Public.ViewEvent.Partials.PDFTicket', $data);
     }
 
+    public function showOrderDoc($folder_name, $file_name)
+    {
+        $fp = Storage::disk('local')->path('docs').'/'.$folder_name.'/'.$file_name;
+        if(is_file($fp)) {
+            return response()->file($fp);
+        }
+        else {
+            // Prevent bruteforce
+            sleep(1);
+            return response("Not found", 404);
+        }
+    }
 }

--- a/app/Jobs/RemoveOldTempFiles.php
+++ b/app/Jobs/RemoveOldTempFiles.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class RemoveOldTempFiles implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Log::debug('Running temporary file cleanup...');
+        $directories = Storage::disk('local')->directories('tmp/docs');
+
+        $now = time();
+        $nbFilesDeleted = 0;
+
+        foreach($directories as $dir) {
+            // Those are unix timestamps
+            $folder_modified = Storage::disk('local')->lastModified($dir);
+            // If folder older than an hour
+            if($now - $folder_modified > 3600) {
+                Storage::disk('local')->deleteDirectory($dir);
+                $nbFilesDeleted = $nbFilesDeleted + 1;
+            }
+        }
+
+        switch($nbFilesDeleted) {
+            case 0:
+                Log::debug('No temporary files deleted');
+            break;
+            case 1:
+                Log::debug('One temporary file deleted');
+            break;
+            default:
+                Log::debug("$nbFilesDeleted temporary files deleted");
+            break;
+        }
+    }
+}

--- a/config/attendize.php
+++ b/config/attendize.php
@@ -59,6 +59,7 @@ return [
     'question_dropdown_multi'       => 4,
     'question_checkbox_multi'       => 5,
     'question_radio_single'         => 6,
+    'question_file_single'          => 7,
 
 
     'default_timezone'              => 30, #Europe/Dublin

--- a/database/migrations/2022_10_24_150136_add_file_question.php
+++ b/database/migrations/2022_10_24_150136_add_file_question.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFileQuestion extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Add the new file type question
+        DB::table('question_types')->insert(
+            array(
+                'alias' => 'file_single',
+                'name' => 'File upload',
+                'has_options' => 0,
+                'allow_multiple' => 1
+            )
+            );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Remove the new question type
+        DB::delete('DELETE FROM question_types WHERE alias=\'file_single\'');
+    }
+}

--- a/public/assets/javascript/frontend.js
+++ b/public/assets/javascript/frontend.js
@@ -4800,19 +4800,13 @@ function processFormErrors($form, errors)
         var selector = (index.indexOf(".") >= 0) ? '.' + index.replace(/\./g, "\\.") : ':input[name=' + index + ']';
         var $input = $(selector, $form);
 
-        if ($input.prop('type') === 'file') {
-            $('#input-' + $input.prop('name')).append('<div class="help-block error">' + error + '</div>')
-                .parent()
-                .addClass('has-error');
-        } else {
-            if($input.parent().hasClass('input-group')) {
-                $input = $input.parent();
-            }
-
-            $input.after('<div class="help-block error">' + error + '</div>')
-                .parent()
-                .addClass('has-error');
+        if($input.parent().hasClass('input-group')) {
+            $input = $input.parent();
         }
+
+        $input.after('<div class="help-block error">' + error + '</div>')
+            .parent()
+            .addClass('has-error');
     });
 
     var $submitButton = $form.find('input[type=submit]');

--- a/resources/lang/en/ManageEvent.php
+++ b/resources/lang/en/ManageEvent.php
@@ -59,6 +59,7 @@ return array (
   'no_attendees_yet_text' => 'Attendees will appear here once they successfully registered for your event, or, you can manually invite attendees yourself.',
   'no_orders_yet' => 'No orders yet',
   'no_orders_yet_text' => 'New orders will appear here as they are created.',
+  'open_file' => 'Open file',
   'order_contact_will_receive_instructions' => 'The order contact will be instructed to send any reply to :email',
   'order_details' => 'Order Details',
   'order_overview' => 'Order Overview',

--- a/resources/views/ManageEvent/Modals/ViewAnswers.blade.php
+++ b/resources/views/ManageEvent/Modals/ViewAnswers.blade.php
@@ -41,7 +41,11 @@
                                            {{ $answer->attendee->ticket->title }}
                                        </td>
                                        <td>
-                                           {!! nl2br(e($answer->answer_text)) !!}
+                                        @if($question->question_type_id == config('attendize.question_file_single'))
+                                            <a target="_blank" href="{!! url($answer->answer_text) !!}">@lang('ManageEvent.open_file')</a>
+                                        @else
+                                            {!! nl2br(e($answer->answer_text)) !!}
+                                        @endif
                                        </td>
                                    </tr>
                                @endforeach

--- a/resources/views/Public/ViewEvent/Partials/AttendeeQuestions.blade.php
+++ b/resources/views/Public/ViewEvent/Partials/AttendeeQuestions.blade.php
@@ -33,6 +33,9 @@
                     <label for="{{ $radio_id }}">{{$option->name}}</label>
                 </div>
                 @endforeach
+            @elseif($question->question_type_id == config('attendize.question_file_single'))
+                <br>
+                {!! Form::file("ticket_holder_files[{$ticket->id}][{$i}][$question->id]", [$question->is_required ? 'required' : '', 'class' => "ticket_holder_files.{$ticket->id}.{$i}.{$question->id} ticket_holder_files form-control", 'id' => "ticket_holder_files[{$ticket->id}][{$i}][{$question->id}]"]) !!}
             @endif
 
         </div>

--- a/resources/views/Public/ViewEvent/Partials/EventCreateOrderSection.blade.php
+++ b/resources/views/Public/ViewEvent/Partials/EventCreateOrderSection.blade.php
@@ -58,7 +58,7 @@
         </div>
         <div class="col-md-8 col-md-pull-4">
             <div class="event_order_form">
-                {!! Form::open(['url' => route('postValidateOrder', ['event_id' => $event->id ]), 'class' => 'ajax payment-form']) !!}
+                {!! Form::open(['url' => route('postValidateOrder', ['event_id' => $event->id ]), 'class' => 'ajax payment-form', 'files' => true]) !!}
 
                 {!! Form::hidden('event_id', $event->id) !!}
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -200,6 +200,10 @@ Route::group(
         [EventCheckoutController::class, 'showOrderTickets']
     )->name('showOrderTickets');
 
+    Route::get('docs/{folder_name}/{file_name}',
+        [EventCheckoutController::class, 'showOrderDoc']
+    )->name('showOrderDoc');
+
     /*
      * Backend routes
      */


### PR DESCRIPTION
Hi!

Following issues, I added a file upload question in Attendize surveys (fixes #1041 and fixes #1027).

How does it work ?

- When users submit files, they are validated by : mimetype, size and the 'required' flag of the question
- If files are validated, they are stored in a temporary directory
- If the order is successfull, files are moved in a permanent location
- The partial path to the uploaded documents is stored in ```answer_text``` in the ```question_answers``` table like so ```docs/<custom_hash>/<laravel_file_hash>.ext```

> Publicly accessible ??

Yes, but the files are hidden via the following path structure ```/docs/<custom_hash>/<laravel_file_hash>.ext```

The ```custom_hash``` is made in an effort to make sandwich-proof hashes in case it is possible to get hashes during the order process.

The hash is generated using php time and OS-based randomness [here](https://github.com/storca/Attendize/commit/a8aab86c340afff321e607221f8e8ac366fcc2b4#diff-68a094e6975d52e95452423f68eab7168d38e01469fabbd87b4b2d0a0cd2eceaR726).

Files are not accessible or editable by the user.

Files can also stay on the server in case the order is cancelled or abandoned ; this is why I added a ```RemoveOldTempFiles``` job that removes files that are older than an hour.

I'm happy to share this PR with you, feel free to test it and suggest changes!