### PR TITLE
Fix ticket access codes deselection

### DIFF
--- a/app/Http/Controllers/EventTicketsController.php
+++ b/app/Http/Controllers/EventTicketsController.php
@@ -232,9 +232,6 @@ class EventTicketsController extends MyBaseController
             ]);
         }
 
-        // Check if the ticket visibility changed on update
-        $ticketPreviouslyHidden = (bool)$ticket->is_hidden;
-
         $ticket->title = $request->get('title');
         $ticket->quantity_available = !$request->get('quantity_available') ? null : $request->get('quantity_available');
         $ticket->price = $request->get('price');
@@ -248,16 +245,13 @@ class EventTicketsController extends MyBaseController
         $ticket->save();
 
         // Attach the access codes to the ticket if it's hidden and the code ids have come from the front
+        $ticket->event_access_codes()->detach();
         if ($ticket->is_hidden) {
             $ticketAccessCodes = $request->get('ticket_access_codes', []);
             if (empty($ticketAccessCodes) === false) {
                 // Sync the access codes on the ticket
-                $ticket->event_access_codes()->detach();
                 $ticket->event_access_codes()->attach($ticketAccessCodes);
             }
-        } else if ($ticketPreviouslyHidden) {
-            // Delete access codes on ticket if the visibility changed to visible
-            $ticket->event_access_codes()->detach();
         }
 
         return response()->json([


### PR DESCRIPTION
Hi!

I found a small issue in the UI while working on a feature.

When hidding a ticket and giving it an access code, everything works.

However when you want to remove all the access codes from this ticket and leave it hidden, that last access code that was active on the ticket remains active.

This small fix solves this problem which can be a huge one in certain events.