### PR TITLE
fixed typo mistake for  ticket status 5 in TicketStatusSeeder

### DIFF
--- a/database/seeds/TicketStatusSeeder.php
+++ b/database/seeds/TicketStatusSeeder.php
@@ -30,7 +30,7 @@ class TicketStatusSeeder extends Seeder
             ],
             [
                 'id' => 5,
-                'name' => 'On Sale',
+                'name' => 'Off Sale',
             ],
         ];
 


### PR DESCRIPTION
ticket status 5 in TicketStatusSeeder is assigned to On Sale but it should be 'Off Sale' because the status 4 is 'On Sale' according to the config